### PR TITLE
Add list collector summary type to the census schemas

### DIFF
--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/who_lives_here_section_summary.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/who_lives_here_section_summary.jsonnet
@@ -1,4 +1,5 @@
 {
   id: 'who-lives-here-section-summary',
-  type: 'SectionSummary',
+  title: 'People who live here',
+  type: 'ListCollectorSummary',
 }

--- a/source/jsonnet/england-wales/household/blocks/who-lives-here/who_lives_here_section_summary.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/who-lives-here/who_lives_here_section_summary.jsonnet
@@ -1,4 +1,5 @@
 {
   id: 'who-lives-here-section-summary',
-  type: 'SectionSummary',
+  title: 'People who live here',
+  type: 'ListCollectorSummary',
 }

--- a/source/jsonnet/northern-ireland/household/blocks/who-lives-here/who_lives_here_section_summary.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/who-lives-here/who_lives_here_section_summary.jsonnet
@@ -1,4 +1,5 @@
 {
   id: 'who-lives-here-section-summary',
-  type: 'SectionSummary',
+  title: 'People who live here',
+  type: 'ListCollectorSummary',
 }


### PR DESCRIPTION
I have updated the Census schemas so that they use the new `list collector summary` type. This change has been made as part of following [PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/28).