### PR TITLE
Add voluntary property to radio answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ Build commands are only executed for english versions of schemas, due to changes
 | test-translation-templates | Tests that current translation templates are up to date |
 
 
-## Testing built census schemas with eq-questionnaire-runner
+## Testing built schemas with eq-questionnaire-runner
 
-In order to test the census schemas built in this repo you will need to create a symbolic link between a /schemas directory in runner and the schemas directory that is generated here. 
+In order to test the schemas built in this repo you will need to create a symbolic link between a /schemas directory in runner and the schemas directory that is generated here. 
 
 In eq-questionnaire-schemas:
 
-Use `make build` to generate the census schemas and populate the /schema directory.
+Use `make build` to generate the schemas and populate the /schema directory.
 
 In your local eq-questionnaire-runner repository:
 
 Remove the `/schemas` directory if it already exists
 
-Create a symbolic link pointing at your generated census schema files by running the following command:
+Create a symbolic link pointing at your generated schema files by running the following command:
 ```
 ln -s <PATH_TO_REPO>/eq-questionnaire-schemas/schemas <PATH_TO_REPO>/eq-questionnaire-runner/schemas
 ```
-You should now be able launch a questionnaire using one of the cenus schemas.
+You should now be able launch a questionnaire using one of the schemas.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Remove the `/schemas` directory if it already exists
 
 Create a symbolic link pointing at your generated census schema files by running the following command:
 ```
-ln -s /eq-questionnaire-schemas/schemas /eq-questionnaire-runner/schemas
+ln -s <PATH_TO_REPO>/eq-questionnaire-schemas/schemas <PATH_TO_REPO>/eq-questionnaire-runner/schemas
 ```
 You should now be able launch a questionnaire using one of the cenus schemas.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,22 @@ Build commands are only executed for english versions of schemas, due to changes
 | translate-schemas | Translate english schemas |
 | translation-templates | Extracts empty templates for translation (.pot) |
 | test-translation-templates | Tests that current translation templates are up to date |
+
+
+## Testing built census schemas with eq-questionnaire-runner
+
+In order to test the census schemas built in this repo you will need to create a symbolic link between a /schemas directory in runner and the schemas directory that is generated here. 
+
+In eq-questionnaire-schemas:
+
+Use `make build` to generate the census schemas and populate the /schema directory.
+
+In your local eq-questionnaire-runner repository:
+
+Remove the `/schemas` directory if it already exists
+
+Create a symbolic link pointing at your generated census schema files by running the following command:
+```
+ln -s /eq-questionnaire-schemas/schemas /eq-questionnaire-runner/schemas
+```
+You should now be able launch a questionnaire using one of the cenus schemas.

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/birth_gender.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/birth_gender.jsonnet
@@ -17,6 +17,7 @@ local question(title, label) = {
       id: 'birth-gender-answer',
       mandatory: false,
       label: '',
+      voluntary: true,
       options: [
         {
           label: 'Yes',
@@ -29,7 +30,6 @@ local question(title, label) = {
             id: 'birth-gender-answer-other',
             type: 'TextField',
             mandatory: false,
-            voluntary: true,
             label: label,
             visible: true,
           },

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/birth_gender.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/birth_gender.jsonnet
@@ -29,6 +29,7 @@ local question(title, label) = {
             id: 'birth-gender-answer-other',
             type: 'TextField',
             mandatory: false,
+            voluntary: true,
             label: label,
             visible: true,
           },

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion.jsonnet
@@ -68,11 +68,12 @@ local question(title, region_code) = (
               id: 'religion-answer-other',
               type: 'TextField',
               mandatory: false,
+              voluntary: true,
               label: 'Enter religion',
             },
           },
         ],
-        type: 'Checkbox',
+        type: 'Radio',
       },
     ],
   }

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion.jsonnet
@@ -30,6 +30,7 @@ local question(title, region_code) = (
         id: 'religion-answer',
         mandatory: false,
         label: '',
+        voluntary: true,
         options: [
           {
             label: 'No religion',
@@ -68,7 +69,6 @@ local question(title, region_code) = (
               id: 'religion-answer-other',
               type: 'TextField',
               mandatory: false,
-              voluntary: true,
               label: 'Enter religion',
             },
           },

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_identity.jsonnet
@@ -19,7 +19,7 @@ local question(title, label) = {
       label: '',
       options: [
         {
-          label: 'Straight or Heterosexual',
+          label: 'Straight',
           value: 'Straight or Heterosexual',
         },
         {
@@ -38,6 +38,7 @@ local question(title, label) = {
             type: 'TextField',
             mandatory: false,
             label: label,
+            voluntary: true,
             visible: true,
           },
         },

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_identity.jsonnet
@@ -17,6 +17,7 @@ local question(title, label) = {
       id: 'sexual-identity-answer',
       mandatory: false,
       label: '',
+      voluntary: true,
       options: [
         {
           label: 'Straight or Heterosexual',
@@ -38,7 +39,6 @@ local question(title, label) = {
             type: 'TextField',
             mandatory: false,
             label: label,
-            voluntary: true,
             visible: true,
           },
         },

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_identity.jsonnet
@@ -19,7 +19,7 @@ local question(title, label) = {
       label: '',
       options: [
         {
-          label: 'Straight',
+          label: 'Straight or Heterosexual',
           value: 'Straight or Heterosexual',
         },
         {


### PR DESCRIPTION
### What is the context of this PR?
This adds new boolean "voluntary" property to radio answer in certain questions described on [this Trello card](https://trello.com/c/Wu3oraFw/3424-voluntary-questions-m). It requires [this runner branch](https://github.com/ONSdigital/eq-questionnaire-runner/pull/31) to be merged first.
[Quick launcher](https://v3-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&case_type=HI&region_code=GB-ENG&url=https://gist.githubusercontent.com/petechd/01d6264d903a82bba04960ea2bfa5f06/raw/79129cc0723c3f8392d5420e49d7b91ed2c6bf8e/census_individual_gb_eng.json)

### How to review 
Check that clear button and voluntary property works as expected in census schemas. Symlink schemas from this branch with runner local branch as described in README file. Currently, this change is not implemented in N.I. census schemas. Religion question type change to radio was one of the requirements of the Trello card.