### PR TITLE
Update date of birth validation (HI/HH)(ENG/WLS/NI)

### DIFF
--- a/scripts/build_schemas.sh
+++ b/scripts/build_schemas.sh
@@ -9,8 +9,8 @@ for region_code in GB-WLS GB-ENG GB-NIR; do
     # Lowercase the region code and replace '-' with '_'
     FORMATTED_REGION_CODE=$(echo "${region_code}" | tr '[:upper:]' '[:lower:]' | tr - _)
 
-    CENSUS_DATE="2019-10-13"
-    CENSUS_MONTH_YEAR_DATE="2019-10"
+    CENSUS_DATE="2021-03-21"
+    CENSUS_MONTH_YEAR_DATE="2021-03"
 
     for census_type in "individual" "household" "communal_establishment"; do
 

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/date_of_birth.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/date_of_birth.jsonnet
@@ -21,6 +21,8 @@ local question(title, census_date) = {
         value: census_date,
         offset_by: {
           years: -115,
+          months: -2,
+          days: -20,
         },
       },
       maximum: {

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/date_of_birth.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/date_of_birth.jsonnet
@@ -21,6 +21,8 @@ local question(title, census_date) = {
         value: census_date,
         offset_by: {
           years: -115,
+          months: -2,
+          days: -20,
         },
       },
       maximum: {


### PR DESCRIPTION
## Context

The validation for the `date-of-birth` question on the household and individual schemas needed to be updated to allow dates from 01/01/1906.

## How to Review
Check that the HH and HI schemas for all regions only allow a DOB after 31/12/1905 to be entered.