### PR TITLE
Add enabled option on relationship section and remove the skips from the blocks

### DIFF
--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -176,16 +176,16 @@ function(region_code, census_month_year_date) {
           ],
         },
       ],
-      "enabled": [
+      enabled: [
         {
-          "when": [
+          when: [
             {
-              "list": "household",
-              "condition": "greater than",
-              "value": 1
-            }
-          ]
-        }
+              list: 'household',
+              condition: 'greater than',
+              value: 1,
+            },
+          ],
+        },
       ],
     },
     {

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -176,6 +176,17 @@ function(region_code, census_month_year_date) {
           ],
         },
       ],
+      "enabled": [
+        {
+          "when": [
+            {
+              "list": "household",
+              "condition": "greater than",
+              "value": 1
+            }
+          ]
+        }
+      ],
     },
     {
       id: 'accommodation-section',

--- a/source/jsonnet/england-wales/household/blocks/relationships/relationships_collector.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/relationships/relationships_collector.jsonnet
@@ -70,17 +70,6 @@ local firstPersonNamePossessivePlaceholder = {
   id: 'relationships',
   title: 'Household relationships',
   for_list: 'household',
-  skip_conditions: [
-    {
-      when: [
-        {
-          list: 'household',
-          condition: 'less than',
-          value: 2,
-        },
-      ],
-    },
-  ],
   question_variants: [
     {
       question: {

--- a/source/jsonnet/england-wales/household/blocks/relationships/relationships_interstitial.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/relationships/relationships_interstitial.jsonnet
@@ -1,17 +1,6 @@
 {
   type: 'Interstitial',
   id: 'relationships-interstitial',
-  skip_conditions: [
-    {
-      when: [
-        {
-          list: 'household',
-          condition: 'less than',
-          value: 2,
-        },
-      ],
-    },
-  ],
   content: {
     title: 'Household relationships',
     contents: [

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -163,6 +163,17 @@ function(region_code) {
           ],
         },
       ],
+      enabled: [
+        {
+          when: [
+            {
+              list: 'household',
+              condition: 'greater than',
+              value: 1,
+            },
+          ],
+        },
+      ],
     },
     {
       id: 'accommodation-section',

--- a/source/jsonnet/northern-ireland/household/blocks/relationships/relationships_collector.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/relationships/relationships_collector.jsonnet
@@ -70,17 +70,6 @@ local firstPersonNamePossessivePlaceholder = {
   id: 'relationships',
   title: 'Household relationships',
   for_list: 'household',
-  skip_conditions: [
-    {
-      when: [
-        {
-          list: 'household',
-          condition: 'less than',
-          value: 2,
-        },
-      ],
-    },
-  ],
   question_variants: [
     {
       question: {

--- a/source/jsonnet/northern-ireland/household/blocks/relationships/relationships_interstitial.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/relationships/relationships_interstitial.jsonnet
@@ -1,17 +1,6 @@
 {
   type: 'Interstitial',
   id: 'relationships-interstitial',
-  skip_conditions: [
-    {
-      when: [
-        {
-          list: 'household',
-          condition: 'less than',
-          value: 2,
-        },
-      ],
-    },
-  ],
   content: {
     title: 'Household relationships',
     contents: [


### PR DESCRIPTION
Currently, on the census schemas, if you don't have at least 2 people then the skip condition on the relationship block skips it and take you to the hub. We need to uses the enabled option on the schema instead and remove the skips