### PR TITLE
Update size of text area field for job description question ENG/WLS HH/HI

### DIFF
--- a/source/jsonnet/england-wales/individual/blocks/employment/job_description.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/job_description.jsonnet
@@ -10,6 +10,7 @@ local question(title) = {
       id: 'job-description-answer',
       label: 'Job description',
       max_length: 120,
+      rows: 4,
       mandatory: false,
       type: 'TextArea',
     },


### PR DESCRIPTION
### Context
This PR updates the `TextArea` field size for the` job-description` question (ENG/WLS schema) from 8 to 4 rows (the `job-description` question for NI is currently a `TextField` and is to be updated later).

### How to Review
Check the field size for the `job-description` question