### PR TITLE
Fix routing issue in visitors section (ENG/WLS)

### DIFF
--- a/source/jsonnet/england-wales/household/blocks/visitor/usual_household_address_details.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/visitor/usual_household_address_details.jsonnet
@@ -47,4 +47,11 @@ local rules = import 'rules.libsonnet';
       },
     ],
   },
+  routing_rules: [
+    {
+      goto: {
+        group: 'visitor-submit-group',
+      },
+    },
+  ],
 }


### PR DESCRIPTION
### Context
This PR fixes a routing issue in the visitors section (ENG/WLS HH).

Previously the `usual-household-address-details` question was incorrectly routing to the `usual-household-address-other` question rather than the `visitor-summary` page.

### How to review
Check that both the `usual-household-address-details` and `usual-household-address-other` questions in the visitors section route to the `visitor-summary`.