### PR TITLE
Add text field limit to job description in NISRA

### DIFF
--- a/source/jsonnet/northern-ireland/individual/blocks/employment/job_description.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/employment/job_description.jsonnet
@@ -9,6 +9,7 @@ local question(title) = {
     {
       id: 'job-description-answer',
       label: 'Job description',
+      max_length: 120,
       mandatory: false,
       rows: 4,
       type: 'TextArea',


### PR DESCRIPTION
### What is the context of this PR?
This sets field length attribute to 120 characters in `job-description` answer. NI schemas only.

### How to review 
Check that there is a 120 characters limit in the actual question when running a NI schema.
