### PR TITLE
Upload schemas to GCS on PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,9 @@ Describe the steps required to test the changes (include screenshots if appropri
 ### Checklist
 
 * [ ] Jsonnet files conform to the latest [style guide](../style_guide.md)
+
+### Schemas Artifacts
+Schemas artifacts are available at:
+```bash
+https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch_name>/schemas/en/<schema_name>.json
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Describe the steps required to test the changes (include screenshots if appropri
 
 ### Checklist
 
-* [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/.github/style_guide.md)
+* [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)
 
 ### Schemas Artifacts
 Schemas artifacts are available at:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -77,7 +77,9 @@ jobs:
           version: 'latest'
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SCHEMAS_BUCKET_SA_KEY }}
-      - name: Upload Schemas To GCS
+      - name: Upload Schemas To GCS & Set Cache Control Headers
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          gsutil -m cp -r schemas gs://${{ secrets.GCS_SCHEMAS_BUCKET }}/${BRANCH_NAME}/
+          BUCKET_URI="gs://${{ secrets.GCS_SCHEMAS_BUCKET }}/${BRANCH_NAME}/"
+          gsutil -m cp -r schemas ${BUCKET_URI}
+          gsutil -m setmeta -h "Cache-Control:private, max-age=0, no-transform" "${BUCKET_URI}**"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,8 +43,8 @@ jobs:
         id: cache-virtualenv
         uses: actions/cache@v1
         with:
-            path: ~/.local/share/virtualenvs/
-            key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-virtualenvs-${{ hashFiles('Pipfile.lock') }}
+          path: ~/.local/share/virtualenvs/
+          key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-virtualenvs-${{ hashFiles('Pipfile.lock') }}
       - name: Install virtual environment
         if: steps.cache-virtualenv.outputs.cache-hit != 'true'
         run: pipenv install --dev
@@ -62,3 +62,21 @@ jobs:
       - run: make run-validator
       - name: Validate schemas
         run: make validate-schemas
+  upload-schemas-to-gcs:
+    needs: validate-schemas
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download built schemas
+        uses: actions/download-artifact@v1
+        with:
+          name: schemas
+      - name: Authenticate & Upload Schemas To GCS
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: 'latest'
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SCHEMAS_BUCKET_SA_KEY }}
+      - run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          gsutil -m cp -r schemas gs://${{ secrets.GCS_SCHEMAS_BUCKET }}/${BRANCH_NAME}/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,12 +71,13 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: schemas
-      - name: Authenticate & Upload Schemas To GCS
+      - name: Authenticate With Google Cloud
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: 'latest'
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SCHEMAS_BUCKET_SA_KEY }}
-      - run: |
+      - name: Upload Schemas To GCS
+        run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           gsutil -m cp -r schemas gs://${{ secrets.GCS_SCHEMAS_BUCKET }}/${BRANCH_NAME}/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,6 +80,5 @@ jobs:
       - name: Upload Schemas To GCS & Set Cache Control Headers
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          BUCKET_URI="gs://${{ secrets.GCS_SCHEMAS_BUCKET }}/${BRANCH_NAME}/"
-          gsutil -m cp -r schemas ${BUCKET_URI}
-          gsutil -m setmeta -h "Cache-Control:private, max-age=0, no-transform" "${BUCKET_URI}**"
+          gsutil -m -h "Cache-Control:private, max-age=0, no-transform" \
+          cp -r schemas "gs://${{ secrets.GCS_SCHEMAS_BUCKET }}/${BRANCH_NAME}/"


### PR DESCRIPTION
### What is the context of this PR?
Uploads the built schemas artifacts to a GCS bucket which are available to be referenced by a quick launch link.

If required, a load balancer with a CDN can be set up with a DNS record instead of using the standard google apis link. By default, the objects are cached for 1 hour, therefore, I have set the necessary headers to prevent client-side cache so that the changes are available immediately.

### How to review 
- Make a PR with this base branch and ensure the schemas are uploaded and are available at the link below.
- OR ensure the artifacts from this PR has been uploaded.
- Ensure, new commits overwrite old artifacts.

### Checklist

* [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Schemas Artifacts
Schemas artifacts are available at:
```bash
https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch_name>/schemas/en/<schema_name>.json
```

> For this PR, ENG HH: https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/push-schemas-to-gcr-on-pr/schemas/en/census_household_gb_eng.json

> Yes, PR branch says gcr instead of gcs!