### PR TITLE
NISRA term time address routing changes

### DIFF
--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_address.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_address.jsonnet
@@ -58,7 +58,7 @@ local proxyTitle = 'Enter details of their term time address.';
   routing_rules: [
     {
       goto: {
-        section: 'End',
+        group: 'identity-and-health-group',
       },
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_country_outside_uk.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_country_outside_uk.jsonnet
@@ -37,7 +37,7 @@ local question(title) = {
   routing_rules: [
     {
       goto: {
-        section: 'End',
+        group: 'identity-and-health-group',
       },
     },
   ],


### PR DESCRIPTION
### What is the context of this PR?
This PR updates the routing from the NISRA `term-time-address` questions so that they route to the `country-of-birth` question rather than the end of the survey.

### How to review
Check that the routing is correct. 

[Quick Launcher](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/nisra-term-time-routing/schemas/en/census_individual_gb_nir.json)

### Checklist

* [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Schemas Artifacts
Schemas artifacts are available at:
```bash
https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/nisra-term-time-routing/schemas/en/census_individual_gb_nir.json
```