### PR TITLE
Turn off section summaries for non WLH sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,35 @@
 ### What is the context of this PR?
+
 Describe what you have changed and why, link to other PRs or Issues as appropriate.
 
 ### How to review
+
 Describe the steps required to test the changes (include screenshots if appropriate).
 
 ### Checklist
 
-* [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)
+- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)
 
 ### Schemas Artifacts
+
 Schemas artifacts are available at:
+
 ```bash
 https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch_name>/schemas/en/<schema_name>.json
 ```
+
+### Quick Launch
+
+#### England & Wales
+
+[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch-name>/schemas/en/census_household_gb_eng.json)
+
+[individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch-name>/schemas/en/census_individual_gb_eng.json)
+
+[ccs](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch-name>/schemas/en/ccs_household_gb_eng.json)
+
+#### Northern Ireland
+
+[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_nir.json)
+
+[individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/ccs_household.json)

--- a/source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/source/jsonnet/england-wales/ccs_household.jsonnet
@@ -92,7 +92,7 @@ function(region_code, census_month_year_date) {
       id: 'who-lives-here-section',
       title: 'People who live here',
       summary: {
-        show_on_completion: false,
+        show_on_completion: true,
         items: [
           {
             type: 'List',
@@ -137,7 +137,7 @@ function(region_code, census_month_year_date) {
     {
       id: 'accommodation-section',
       title: 'Household accommodation',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       groups: [
         {
           id: 'accommodation-group',
@@ -160,7 +160,7 @@ function(region_code, census_month_year_date) {
     {
       id: 'individual-section',
       title: 'Individual Section',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       repeat: {
         for_list: 'household',
         title: {

--- a/source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/source/jsonnet/england-wales/ccs_household.jsonnet
@@ -92,7 +92,7 @@ function(region_code, census_month_year_date) {
       id: 'who-lives-here-section',
       title: 'People who live here',
       summary: {
-        show_on_completion: true,
+        show_on_completion: false,
         items: [
           {
             type: 'List',

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -165,7 +165,7 @@ function(region_code, census_month_year_date) {
       id: 'who-lives-here-section',
       title: 'People who live here',
       summary: {
-        show_on_completion: true,
+        show_on_completion: false,
         items: [
           {
             type: 'List',

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -165,7 +165,7 @@ function(region_code, census_month_year_date) {
       id: 'who-lives-here-section',
       title: 'People who live here',
       summary: {
-        show_on_completion: false,
+        show_on_completion: true,
         items: [
           {
             type: 'List',
@@ -233,7 +233,7 @@ function(region_code, census_month_year_date) {
     {
       id: 'accommodation-section',
       title: 'Household accommodation',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       groups: [
         {
           id: 'accommodation-group',
@@ -256,7 +256,7 @@ function(region_code, census_month_year_date) {
     {
       id: 'individual-section',
       title: 'Individual Section',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       repeat: {
         for_list: 'household',
         title: {
@@ -395,7 +395,7 @@ function(region_code, census_month_year_date) {
     {
       id: 'visitor-section',
       title: 'Visitors',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       repeat: {
         for_list: 'visitors',
         title: {

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -153,7 +153,7 @@ function(region_code) {
       id: 'who-lives-here-section',
       title: 'People who live here',
       summary: {
-        show_on_completion: false,
+        show_on_completion: true,
         items: [
           {
             type: 'List',
@@ -221,7 +221,7 @@ function(region_code) {
     {
       id: 'accommodation-section',
       title: 'Household accommodation',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       groups: [
         {
           id: 'accommodation-group',
@@ -244,7 +244,7 @@ function(region_code) {
     {
       id: 'individual-section',
       title: 'Individual Section',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       repeat: {
         for_list: 'household',
         title: {
@@ -377,7 +377,7 @@ function(region_code) {
     {
       id: 'visitor-section',
       title: 'Visitors',
-      summary: { show_on_completion: true },
+      summary: { show_on_completion: false },
       repeat: {
         for_list: 'visitors',
         title: {

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -153,7 +153,7 @@ function(region_code) {
       id: 'who-lives-here-section',
       title: 'People who live here',
       summary: {
-        show_on_completion: true,
+        show_on_completion: false,
         items: [
           {
             type: 'List',


### PR DESCRIPTION
### What is the context of this PR?
Turns off the section summaries for non who lives here section in the following schemas:
1. CCS household England
1. CCS household Wales
1. Census household England
1. Census household Wales
1. Census household NI

### How to review
Test the section summaries for who lives here sections does not appear on the forward journey in the relevant schemas

### Checklist

* [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Schemas Artifacts
Schemas artifacts are available at:
```bash
https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch_name>/schemas/en/<schema_name>.json
```
### Quick Launch

#### England & Wales
<a href="https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/wlh-turn-off-summaries/schemas/en/census_household_gb_eng.json" target="_blank">household</a>
[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/wlh-turn-off-summaries/schemas/en/census_household_gb_eng.json)

[individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/wlh-turn-off-summaries/schemas/en/census_individual_gb_eng.json)

#### Northern Ireland

[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/wlh-turn-off-summaries/schemas/en/census_household_gb_nir.json)

[individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/wlh-turn-off-summaries/schemas/en/census_individual_gb_nir.json)