### PR TITLE
Add changes to the hub

### DIFF
--- a/source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/source/jsonnet/england-wales/ccs_household.jsonnet
@@ -85,6 +85,16 @@ function(region_code, census_month_year_date) {
   ],
   hub: {
     enabled: true,
+    complete: {
+      title: 'Submit census',
+      guidance: 'Please submit this census to complete it',
+    },
+    incomplete: {
+      guidance: 'You must complete all sections in order to complete this census',
+    },
+    submission: {
+      button: 'Submit census',
+    },
     required_completed_sections: ['who-lives-here-section'],
   },
   sections: [

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -158,6 +158,16 @@ function(region_code, census_month_year_date) {
   ],
   hub: {
     enabled: true,
+    complete: {
+      title: 'Submit census',
+      guidance: 'Please submit this census to complete it',
+    },
+    incomplete: {
+      guidance: 'You must complete all sections in order to complete this census',
+    },
+    submission: {
+      button: 'Submit census',
+    },
     required_completed_sections: ['who-lives-here-section', 'relationships-section'],
   },
   sections: [

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -146,6 +146,16 @@ function(region_code) {
   ],
   hub: {
     enabled: true,
+    complete: {
+      title: 'Submit census',
+      guidance: 'Please submit this census to complete it',
+    },
+    incomplete: {
+      guidance: 'You must complete all sections in order to complete this census',
+    },
+    submission: {
+      button: 'Submit census',
+    },
     required_completed_sections: ['who-lives-here-section', 'relationships-section'],
   },
   sections: [

--- a/translations/ccs_household_gb_eng.pot
+++ b/translations/ccs_household_gb_eng.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-20 09:12+0100\n"
+"POT-Creation-Date: 2020-05-29 10:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -218,6 +218,9 @@ msgid "People staying temporarily who did not have another UK address"
 msgstr ""
 
 msgid "2019 Census Coverage Survey Test"
+msgstr ""
+
+msgid "Submit census"
 msgstr ""
 
 msgid "People who live here"

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-20 14:29+0100\n"
+"POT-Creation-Date: 2020-05-29 10:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -741,6 +741,9 @@ msgid "{second_person_name} is <em>unrelated</em> to {first_person_name}"
 msgstr ""
 
 msgid "2019 Census Test"
+msgstr ""
+
+msgid "Submit census"
 msgstr ""
 
 msgid "People who live here"

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-05-20 09:12+0100\n"
+"POT-Creation-Date: 2020-05-29 10:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1049,6 +1049,9 @@ msgid "{second_person_name} is <em>unrelated</em> to {first_person_name}"
 msgstr ""
 
 msgid "2019 Census Test"
+msgstr ""
+
+msgid "Submit census"
 msgstr ""
 
 msgid "People who live here"


### PR DESCRIPTION
### What is the context of this PR?
This adds new, census-specific text to title, guidance and button of the hub. Non-census schemas with the hub remain the same. The change is described on this [Trello card](https://trello.com/c/dcfsAeIJ). It was configured using this [feature](https://github.com/ONSdigital/eq-questionnaire-runner/pull/117). Affected schemas: ccs, household.

### How to review 
Run tests, check census hub and compare it to test schema's ones(e.g. test_hub_and_spoke.json)

### Checklist

- [] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Schemas Artifacts

Schemas artifacts are available at:

```bash
https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch_name>/schemas/en/<schema_name>.json
```

### Quick Launch

#### England & Wales

[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-changes-to-hub/schemas/en/census_household_gb_eng.json)

[ccs](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-changes-to-hub/schemas/en/ccs_household_gb_eng.json)

#### Northern Ireland

[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-changes-to-hub/schemas/en/census_household_gb_nir.json)

