### PR TITLE
NISRA: Fix age based routing for religion questions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,26 +10,18 @@ Describe the steps required to test the changes (include screenshots if appropri
 
 - [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)
 
-### Schemas Artifacts
-
-Schemas artifacts are available at:
-
-```bash
-https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch_name>/schemas/en/<schema_name>.json
-```
-
 ### Quick Launch
 
-#### England & Wales
+#### England
 
-[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch-name>/schemas/en/census_household_gb_eng.json)
+- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_eng.json)
 
-[individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch-name>/schemas/en/census_individual_gb_eng.json)
+- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_individual_gb_eng.json)
 
-[ccs](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch-name>/schemas/en/ccs_household_gb_eng.json)
+- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/ccs_household_gb_eng.json)
 
 #### Northern Ireland
 
-[household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_nir.json)
+- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_nir.json)
 
-[individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/ccs_household.json)
+- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_individual_gb_nir.json)

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/no_religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/no_religion_other.jsonnet
@@ -57,7 +57,7 @@ local question(title) = {
         block: 'health',
         when: [rules.lastBirthdayAgeLessThan(3)],
       },
-    }
+    },
     {
       goto: {
         block: 'language',

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
@@ -57,7 +57,7 @@ local question(title) = {
         block: 'health',
         when: [rules.lastBirthdayAgeLessThan(3)],
       },
-    }
+    },
     {
       goto: {
         block: 'language',


### PR DESCRIPTION
### What is the context of this PR?

Fixed an issue where built JSON schema was missing some routing rules due to some missing commas. In Jsonnet, objects extend other objects so when merging two objects, the right hand side is chosen when fields collide.

### How to review

Ensure routing rule in the Trello card now works.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-missing-routing-based-on-age/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-missing-routing-based-on-age/schemas/en/census_individual_gb_eng.json)

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-missing-routing-based-on-age/schemas/en/ccs_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-missing-routing-based-on-age/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-missing-routing-based-on-age/schemas/en/census_individual_gb_nir.json)
