### PR TITLE
Update translations to v3.1.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 coloredlogs = "*"
 
 [packages]
-eq-translations = {editable = true,git = "https://github.com/ONSDigital/eq-translations.git",ref = "v3.0.0"}
+eq-translations = {editable = true,git = "https://github.com/ONSDigital/eq-translations.git",ref = "v3.1.0"}
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7c541c92fac1c5e86d317843153330134fbb8c049783bc7ffb28dda3ebd00a31"
+            "sha256": "2cf9c43dd11c5c0c9eba386536c5e6f631517478915bbb5180819cd0e1fc37d5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,7 +47,7 @@
         "eq-translations": {
             "editable": true,
             "git": "https://github.com/ONSDigital/eq-translations.git",
-            "ref": "b99c1525215710932407a50dccdb81d2b4eaffd4"
+            "ref": "3f18cc89245a2f69095720be959f3bcbe1e2a573"
         },
         "idna": {
             "hashes": [

--- a/scripts/eq_translations_check.py
+++ b/scripts/eq_translations_check.py
@@ -18,7 +18,7 @@ try:
         if latest_tag != version:
             logger.error(
                 f'eq-translations is out of date. Update using: "pipenv install -e git+https://github.com/ONSDigital'
-                f'/eq-translations.git@{version}#egg=eq_translations". '
+                f'/eq-translations.git@{latest_tag}#egg=eq_translations". '
             )
             sys.exit(1)
     else:


### PR DESCRIPTION
### What is the context of this PR?

- Updates eq-translations to https://github.com/ONSdigital/eq-translations/releases/tag/v3.1.0
- Also update the translation check script to reference the latest version when promoting for an update.

### How to review

Ensure:
- translation works as expected.
- when eq-translations is out of date, the latest version is display in the helper text.
