### PR TITLE
Add warning message to remove person/ visitor for all household schemas

### DIFF
--- a/source/jsonnet/england-wales/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
@@ -202,17 +202,13 @@ local editQuestion(questionTitle) = {
     question: {
       id: 'remove-question',
       type: 'General',
-      guidance: {
-        contents: [{
-          title: 'All of the data entered about this person will be deleted',
-        }],
-      },
       title: {
         text: 'Are you sure you want to remove <em>{person_name}</em>?',
         placeholders: [
           placeholders.personName,
         ],
       },
+      warning: 'All of the information entered about this person will be deleted',
       answers: [
         {
           id: 'remove-confirmation',

--- a/source/jsonnet/england-wales/household/blocks/who-lives-here/anyone_else_temporarily_away_list_collector.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/who-lives-here/anyone_else_temporarily_away_list_collector.jsonnet
@@ -201,17 +201,13 @@ local editQuestion(questionTitle) = {
     question: {
       id: 'anyone-else-temp-away-remove-question',
       type: 'General',
-      guidance: {
-        contents: [{
-          title: 'All of the data entered about this person will be deleted',
-        }],
-      },
       title: {
         text: 'Are you sure you want to remove <em>{person_name}</em>?',
         placeholders: [
           placeholders.personName,
         ],
       },
+      warning: 'All of the information entered about this person will be deleted',
       answers: [
         {
           id: 'anyone-else-temp-away-remove-confirmation',

--- a/source/jsonnet/england-wales/household/blocks/who-lives-here/visitor_list_collector.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/who-lives-here/visitor_list_collector.jsonnet
@@ -118,17 +118,13 @@ local rules = import 'rules.libsonnet';
     question: {
       id: 'visitor-remove-question',
       type: 'General',
-      guidance: {
-        contents: [{
-          title: 'All of the data entered about this person will be deleted',
-        }],
-      },
       title: {
         text: 'Are you sure you want to remove <em>{person_name}</em>?',
         placeholders: [
           placeholders.personName,
         ],
       },
+      warning: 'All of the information entered about this person will be deleted',
       answers: [
         {
           id: 'visitor-remove-confirmation',

--- a/source/jsonnet/northern-ireland/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
@@ -202,17 +202,13 @@ local editQuestion(questionTitle) = {
     question: {
       id: 'remove-question',
       type: 'General',
-      guidance: {
-        contents: [{
-          title: 'All of the data entered about this person will be deleted',
-        }],
-      },
       title: {
         text: 'Are you sure you want to remove <em>{person_name}</em>?',
         placeholders: [
           placeholders.personName,
         ],
       },
+      warning: 'All of the information entered about this person will be deleted',
       answers: [
         {
           id: 'remove-confirmation',

--- a/source/jsonnet/northern-ireland/household/blocks/who-lives-here/anyone_else_temporarily_away_list_collector.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/who-lives-here/anyone_else_temporarily_away_list_collector.jsonnet
@@ -218,12 +218,8 @@ local editQuestion(questionTitle) = {
     question: {
       id: 'anyone-else-temp-away-remove-question',
       type: 'General',
-      guidance: {
-        contents: [{
-          title: 'All of the data entered about this person will be deleted',
-        }],
-      },
       title: removePersonQuestionTitle,
+      warning: 'All of the information entered about this person will be deleted',
       answers: [
         {
           id: 'anyone-else-temp-away-remove-confirmation',

--- a/source/jsonnet/northern-ireland/household/blocks/who-lives-here/visitor_list_collector.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/who-lives-here/visitor_list_collector.jsonnet
@@ -145,12 +145,8 @@ local removePersonQuestionTitle = {
     question: {
       id: 'visitor-remove-question',
       type: 'General',
-      guidance: {
-        contents: [{
-          title: 'All of the data entered about this person will be deleted',
-        }],
-      },
       title: removePersonQuestionTitle,
+      warning: 'All of the information entered about this person will be deleted',
       answers: [
         {
           id: 'visitor-remove-confirmation',

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-06-08 17:15+0100\n"
+"POT-Creation-Date: 2020-06-09 14:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1479,6 +1479,16 @@ msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
 msgid "For example, 31 3 1970"
 msgstr ""
 
+#. Question warning
+msgctxt "Are you sure you want to remove <em>{person_name}</em>?"
+msgid "All of the information entered about this person will be deleted"
+msgstr ""
+
+#. Question warning
+msgctxt "Are you sure you want to remove {person_name}?"
+msgid "All of the information entered about this person will be deleted"
+msgstr ""
+
 #. Question definition link
 msgctxt "Do you usually live at {household_address}?"
 msgid "What we mean by “usually live”"
@@ -1670,11 +1680,6 @@ msgid "<strong>armed forces members</strong>, if this is their home address"
 msgstr ""
 
 #. Question guidance heading
-msgctxt "Are you sure you want to remove <em>{person_name}</em>?"
-msgid "All of the data entered about this person will be deleted"
-msgstr ""
-
-#. Question guidance heading
 msgctxt ""
 "You said {cardinality} people live at {household_address}. Do you need to"
 " add anyone?"
@@ -1693,11 +1698,6 @@ msgctxt ""
 "You said {cardinality} people live at {household_address}. Do you need to"
 " add anyone?"
 msgid "Temporarily staying"
-msgstr ""
-
-#. Question guidance heading
-msgctxt "Are you sure you want to remove {person_name}?"
-msgid "All of the data entered about this person will be deleted"
 msgstr ""
 
 #. Question guidance heading

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-06-08 17:15+0100\n"
+"POT-Creation-Date: 2020-06-09 14:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1626,6 +1626,11 @@ msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
 msgid "For example, 31 3 1980"
 msgstr ""
 
+#. Question warning
+msgctxt "Are you sure you want to remove <em>{person_name}</em>?"
+msgid "All of the information entered about this person will be deleted"
+msgstr ""
+
 #. Question definition link
 msgctxt "Do you usually live at {household_address}?"
 msgid "What we mean by “usually live”"
@@ -2169,11 +2174,6 @@ msgctxt ""
 "Do any of the following people live at {household_address} on "
 "{census_date}?"
 msgid "<strong>armed forces members</strong>, if this is their home address"
-msgstr ""
-
-#. Question guidance heading
-msgctxt "Are you sure you want to remove <em>{person_name}</em>?"
-msgid "All of the data entered about this person will be deleted"
 msgstr ""
 
 #. Question guidance heading


### PR DESCRIPTION
### What is the context of this PR?
The new feature for warning messages has been added to remove person and remove visitor for all household schemas

### How to review
Check the right schemas have been updated

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-warnings-to-remove-person-visitor-household/schemas/en/census_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-warnings-to-remove-person-visitor-household/schemas/en/census_household_gb_nir.json)
