### PR TITLE
Fix mismatching answer default and options value

### DIFF
--- a/source/jsonnet/northern-ireland/household/blocks/individual/proxy.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/individual/proxy.jsonnet
@@ -17,7 +17,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
       {
         id: 'proxy-answer',
         mandatory: false,
-        default: 'No',
+        default: 'No, I am answering on their behalf',
         options: [
           {
             label: 'Yes, I am',


### PR DESCRIPTION
### What is the context of this PR?

This fixes a bug described on following [Trello card](https://trello.com/c/ohpvGLAQ). New [validator rule](https://github.com/ONSdigital/eq-questionnaire-validator/pull/44) is added to prevent this from happening in the future.

### How to review

In quick launch NISRA household schema, when proxy question left unanswered, it should not cause an error anymore.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/nisra-proxy-bug/schemas/en/census_household_gb_nir.json)

