### PR TITLE
CCS: Add interviewer note

### DIFF
--- a/source/jsonnet/england-wales/ccs/blocks/accommodation/respondent_living_at.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/accommodation/respondent_living_at.jsonnet
@@ -3,7 +3,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
 {
   type: 'Question',
   id: 'respondent-living-at',
-  interviewer_only: 'true',
+  interviewer_only: true,
   question: {
     id: 'respondent-living-at-question',
     title: {

--- a/source/jsonnet/england-wales/ccs/blocks/accommodation/respondent_living_at.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/accommodation/respondent_living_at.jsonnet
@@ -3,10 +3,11 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
 {
   type: 'Question',
   id: 'respondent-living-at',
+  interviewer_only: 'true',
   question: {
     id: 'respondent-living-at-question',
     title: {
-      text: 'Interviewer Note: Was the respondent living at {household_address} on Sunday {census_date}?',
+      text: 'Was the respondent living at {household_address} on Sunday {census_date}?',
       placeholders: [placeholders.address, placeholders.censusDate],
     },
     type: 'General',

--- a/source/jsonnet/england-wales/ccs/blocks/individual/proxy.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/individual/proxy.jsonnet
@@ -1,7 +1,7 @@
 {
   type: 'Question',
   id: 'proxy',
-  interviewer_only: 'true',
+  interviewer_only: true,
   question: {
     id: 'proxy-question',
     title: 'Are they answering the questions for themselves or on someone else’s behalf?',

--- a/source/jsonnet/england-wales/ccs/blocks/individual/proxy.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/individual/proxy.jsonnet
@@ -1,9 +1,10 @@
 {
   type: 'Question',
   id: 'proxy',
+  interviewer_only: 'true',
   question: {
     id: 'proxy-question',
-    title: '<em>Interviewer Note:</em> Are they answering the questions for themselves or on someone else’s behalf?',
+    title: 'Are they answering the questions for themselves or on someone else’s behalf?',
     type: 'General',
     answers: [
       {

--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/outside_uk_note.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/outside_uk_note.jsonnet
@@ -3,8 +3,9 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
 {
   type: 'Interstitial',
   id: 'outside-uk-note',
+  interviewer_only: 'true',
   content: {
-    title: 'Interviewer Note',
+    title: 'End of interview',
     instruction: {
       text: 'If the respondent was living outside the UK on Sunday {census_date}, please explain that they do not need to complete the questionnaire and end interview',
       placeholders: [

--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/outside_uk_note.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/outside_uk_note.jsonnet
@@ -3,7 +3,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
 {
   type: 'Interstitial',
   id: 'outside-uk-note',
-  interviewer_only: 'true',
+  interviewer_only: true,
   content: {
     title: 'End of interview',
     instruction: {

--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/who_to_interview_note.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/who_to_interview_note.jsonnet
@@ -1,8 +1,9 @@
 {
   type: 'Interstitial',
   id: 'who-to-interview-note',
+  interviewer_only: 'true',
   content: {
-    title: '<em>Interviewer Note</em>',
+    title: 'Who to interview',
     instruction: 'If the respondent was not living at the property on census night, but other current household members were, you must speak to one of those household members instead. <p>If none of those household members are available, you must return to the address to interview one of them at a later date.</p>',
   },
   routing_rules: [

--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/who_to_interview_note.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/who_to_interview_note.jsonnet
@@ -1,7 +1,7 @@
 {
   type: 'Interstitial',
   id: 'who-to-interview-note',
-  interviewer_only: 'true',
+  interviewer_only: true,
   content: {
     title: 'Who to interview',
     instruction: 'If the respondent was not living at the property on census night, but other current household members were, you must speak to one of those household members instead. <p>If none of those household members are available, you must return to the address to interview one of them at a later date.</p>',

--- a/translations/ccs_household_gb_eng.pot
+++ b/translations/ccs_household_gb_eng.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-14 12:15+0100\n"
+"POT-Creation-Date: 2020-07-15 09:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,7 +110,11 @@ msgid "Your household"
 msgstr ""
 
 #. Content page main heading
-msgid "Interviewer Note"
+msgid "End of interview"
+msgstr ""
+
+#. Content page main heading
+msgid "Who to interview"
 msgstr ""
 
 #. Content page main heading
@@ -267,9 +271,7 @@ msgid "What is the name of the {ordinality} visitor who stayed overnight?"
 msgstr ""
 
 #. Question text
-msgid ""
-"Interviewer Note: Was the respondent living at {household_address} on "
-"Sunday {census_date}?"
+msgid "Was the respondent living at {household_address} on Sunday {census_date}?"
 msgstr ""
 
 #. Question text
@@ -344,8 +346,8 @@ msgstr ""
 
 #. Question text
 msgid ""
-"<em>Interviewer Note:</em> Are they answering the questions for "
-"themselves or on someone else’s behalf?"
+"Are they answering the questions for themselves or on someone else’s "
+"behalf?"
 msgstr ""
 
 #. Question text
@@ -1599,16 +1601,12 @@ msgid "No"
 msgstr ""
 
 #. Answer option
-msgctxt ""
-"Interviewer Note: Was the respondent living at {household_address} on "
-"Sunday {census_date}?"
+msgctxt "Was the respondent living at {household_address} on Sunday {census_date}?"
 msgid "Yes, living at this address"
 msgstr ""
 
 #. Answer option
-msgctxt ""
-"Interviewer Note: Was the respondent living at {household_address} on "
-"Sunday {census_date}?"
+msgctxt "Was the respondent living at {household_address} on Sunday {census_date}?"
 msgid "No, living at a different address"
 msgstr ""
 
@@ -1940,15 +1938,15 @@ msgstr ""
 
 #. Answer option
 msgctxt ""
-"<em>Interviewer Note:</em> Are they answering the questions for "
-"themselves or on someone else’s behalf?"
+"Are they answering the questions for themselves or on someone else’s "
+"behalf?"
 msgid "Yes, they are answering for themselves"
 msgstr ""
 
 #. Answer option
 msgctxt ""
-"<em>Interviewer Note:</em> Are they answering the questions for "
-"themselves or on someone else’s behalf?"
+"Are they answering the questions for themselves or on someone else’s "
+"behalf?"
 msgid "No, they are answering on someone else’s behalf"
 msgstr ""
 


### PR DESCRIPTION
### What is the context of this PR?

This adds new `interviewer_only` key and refactor titles in ccs schemas as described on [Trello card](https://trello.com/c/OPIjOqUR). New translations has been added. This change only works if your design system is up to date and built using `make load-design-system-templates`.

### How to review

Use quick launchers below to compare changes. 

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/implement-interviewer-note/schemas/en/ccs_household_gb_eng.json)

#### Wales

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/implement-interviewer-note/schemas/en/ccs_household_gb_wls.json)
