### PR TITLE
CCS: Make household accommodation and final section conditional

### DIFF
--- a/source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/source/jsonnet/england-wales/ccs_household.jsonnet
@@ -1,3 +1,4 @@
+local rules = import '../../lib/common_rules.libsonnet';
 local placeholders = import '../../lib/placeholders.libsonnet';
 
 // Who lives here
@@ -157,6 +158,13 @@ function(region_code, census_month_year_date) {
       id: 'accommodation-section',
       title: 'Household accommodation',
       summary: { show_on_completion: false },
+      enabled: [
+        {
+          when: [
+            rules.listIsNotEmpty('household'),
+          ],
+        },
+      ],
       groups: [
         {
           id: 'accommodation-group',
@@ -281,6 +289,13 @@ function(region_code, census_month_year_date) {
       summary: {
         show_on_completion: false,
       },
+      enabled: [
+        {
+          when: [
+            rules.listIsNotEmpty('household'),
+          ],
+        },
+      ],
       groups: [
         {
           id: 'household-check-group',

--- a/source/jsonnet/england-wales/lib/common_rules.libsonnet
+++ b/source/jsonnet/england-wales/lib/common_rules.libsonnet
@@ -130,4 +130,9 @@
     condition: 'equals',
     value: 'No, I don’t usually live here',
   },
+  listIsNotEmpty(listName): {
+    list: listName,
+    condition: 'greater than',
+    value: 0,
+  },
 }


### PR DESCRIPTION
### What is the context of this PR?

Makes the `Household accommodation` and Final check - other households` section conditional on the list count.

### How to review

Ensure the `Household accommodation` and Final check - other households` are not shown when the `household` list is empty.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/ccs-conditional-sections/schemas/en/ccs_household_gb_eng.json)