### PR TITLE
Change driver variant on WLH HH

### DIFF
--- a/source/jsonnet/england-wales/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
@@ -2,7 +2,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
 local questionTitle = {
-  text: 'Does anyone usually live at {household_address}?',
+  text: 'Does anyone live at {household_address}?',
   placeholders: [
     placeholders.address,
   ],
@@ -114,7 +114,7 @@ local editQuestion(questionTitle) = {
   for_list: 'household',
   add_answer: {
     id: 'anyone-else-answer',
-    value: 'Yes, I want to add {ordinality} person',
+    value: 'Yes, I need to add a person',
   },
   remove_answer: {
     id: 'remove-confirmation',
@@ -133,18 +133,12 @@ local editQuestion(questionTitle) = {
             type: 'Radio',
             options: [
               {
-                label: {
-                  text: 'Yes, I want to add {ordinality} person',
-                  placeholders: [
-                    placeholders.getListOrdinality('household'),
-                  ],
-                },
-                value: 'Yes, I want to add {ordinality} person',
+                label: 'Yes, I need to add a person',
+                value: 'Yes, I need to add a person',
               },
               {
-                label: 'No, no one usually lives here',
-                value: 'No, no one usually lives here',
-                description: 'For example, this is a second address or holiday home',
+                label: 'No, I do not need to add anyone',
+                value: 'No, I do not need to add anyone',
               },
             ],
           },
@@ -169,13 +163,8 @@ local editQuestion(questionTitle) = {
             type: 'Radio',
             options: [
               {
-                label: {
-                  text: 'Yes, I want to add {ordinality} person',
-                  placeholders: [
-                    placeholders.getListOrdinality('household'),
-                  ],
-                },
-                value: 'Yes, I want to add {ordinality} person',
+                label: 'Yes, I need to add a person',
+                value: 'Yes, I need to add a person',
               },
               {
                 label: 'No, I do not need to add anyone',

--- a/source/jsonnet/northern-ireland/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/who-lives-here/anyone_else_list_collector.jsonnet
@@ -2,7 +2,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
 local questionTitle = {
-  text: 'Does anyone usually live at {household_address}?',
+  text: 'Does anyone live at {household_address}?',
   placeholders: [
     placeholders.address,
   ],
@@ -114,7 +114,7 @@ local editQuestion(questionTitle) = {
   for_list: 'household',
   add_answer: {
     id: 'anyone-else-answer',
-    value: 'Yes, I want to add {ordinality} person',
+    value: 'Yes, I need to add a person',
   },
   remove_answer: {
     id: 'remove-confirmation',
@@ -133,18 +133,12 @@ local editQuestion(questionTitle) = {
             type: 'Radio',
             options: [
               {
-                label: {
-                  text: 'Yes, I want to add {ordinality} person',
-                  placeholders: [
-                    placeholders.getListOrdinality('household'),
-                  ],
-                },
-                value: 'Yes, I want to add {ordinality} person',
+                label: 'Yes, I need to add a person',
+                value: 'Yes, I need to add a person',
               },
               {
-                label: 'No, no one usually lives here',
-                value: 'No, no one usually lives here',
-                description: 'For example, this is a second address or holiday home',
+                label: 'No, I do not need to add anyone',
+                value: 'No, I do not need to add anyone',
               },
             ],
           },
@@ -169,13 +163,8 @@ local editQuestion(questionTitle) = {
             type: 'Radio',
             options: [
               {
-                label: {
-                  text: 'Yes, I want to add {ordinality} person',
-                  placeholders: [
-                    placeholders.getListOrdinality('household'),
-                  ],
-                },
-                value: 'Yes, I want to add {ordinality} person',
+                label: 'Yes, I need to add a person',
+                value: 'Yes, I need to add a person',
               },
               {
                 label: 'No, I do not need to add anyone',

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-20 17:42+0100\n"
+"POT-Creation-Date: 2020-07-22 19:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -383,7 +383,7 @@ msgid "Change details for <em>{person_name}</em>"
 msgstr ""
 
 #. Question text
-msgid "Does anyone usually live at {household_address}?"
+msgid "Does anyone live at {household_address}?"
 msgstr ""
 
 #. Question text
@@ -3160,18 +3160,18 @@ msgid "None of these apply, no-one usually lives here"
 msgstr ""
 
 #. Answer option
-msgctxt "Does anyone usually live at {household_address}?"
-msgid "Yes, I want to add {ordinality} person"
+msgctxt "Does anyone live at {household_address}?"
+msgid "Yes, I need to add a person"
 msgstr ""
 
 #. Answer option
-msgctxt "Does anyone usually live at {household_address}?"
-msgid "No, no one usually lives here"
+msgctxt "Does anyone live at {household_address}?"
+msgid "No, I do not need to add anyone"
 msgstr ""
 
 #. Answer option
 msgctxt "Does anyone else live at {household_address}?"
-msgid "Yes, I want to add {ordinality} person"
+msgid "Yes, I need to add a person"
 msgstr ""
 
 #. Answer option
@@ -6349,12 +6349,6 @@ msgstr ""
 msgctxt ""
 "Do any of the following people live at {household_address} on Sunday "
 "{census_date}?"
-msgid "For example, this is a second address or holiday home"
-msgstr ""
-
-#. Answer option description
-#. For answer option: No, no one usually lives here
-msgctxt "Does anyone usually live at {household_address}?"
 msgid "For example, this is a second address or holiday home"
 msgstr ""
 

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-20 17:42+0100\n"
+"POT-Creation-Date: 2020-07-22 19:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -397,7 +397,7 @@ msgid "Change details for <em>{person_name}</em>"
 msgstr ""
 
 #. Question text
-msgid "Does anyone usually live at {household_address}?"
+msgid "Does anyone live at {household_address}?"
 msgstr ""
 
 #. Question text
@@ -3749,18 +3749,18 @@ msgid "None of these apply, no-one usually lives here"
 msgstr ""
 
 #. Answer option
-msgctxt "Does anyone usually live at {household_address}?"
-msgid "Yes, I want to add {ordinality} person"
+msgctxt "Does anyone live at {household_address}?"
+msgid "Yes, I need to add a person"
 msgstr ""
 
 #. Answer option
-msgctxt "Does anyone usually live at {household_address}?"
-msgid "No, no one usually lives here"
+msgctxt "Does anyone live at {household_address}?"
+msgid "No, I do not need to add anyone"
 msgstr ""
 
 #. Answer option
 msgctxt "Does anyone else live at {household_address}?"
-msgid "Yes, I want to add {ordinality} person"
+msgid "Yes, I need to add a person"
 msgstr ""
 
 #. Answer option
@@ -6746,12 +6746,6 @@ msgstr ""
 msgctxt ""
 "Do any of the following people live at {household_address} on Sunday "
 "{census_date}?"
-msgid "For example, this is a second address or holiday home"
-msgstr ""
-
-#. Answer option description
-#. For answer option: No, no one usually lives here
-msgctxt "Does anyone usually live at {household_address}?"
 msgid "For example, this is a second address or holiday home"
 msgstr ""
 


### PR DESCRIPTION
### What is the context of this PR?
Update anyone-else-list-collector to the 2021 version

### How to review

Use the quick launches and make sure the content is correct

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-driver-variant-anyone-else/schemas/en/census_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-driver-variant-anyone-else/schemas/en/census_household_gb_nir.json)