### PR TITLE
CCS: QA Mop up changes part 2

### DIFF
--- a/source/jsonnet/england-wales/ccs/blocks/accommodation/government_services.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/accommodation/government_services.jsonnet
@@ -24,7 +24,7 @@
           {
             label: 'Applying for official documents online',
             value: 'Applying for official documents online',
-            description: 'For example, passports, driving licence',
+            description: 'For example, passport, driving licence',
           },
           {
             label: 'Used paper-based services',

--- a/source/jsonnet/england-wales/ccs/blocks/accommodation/self_contained.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/accommodation/self_contained.jsonnet
@@ -1,9 +1,9 @@
 local rules = import 'rules.libsonnet';
 
-local question(title) = {
+local question(title, instruction) = {
   id: 'self-contained-question',
   title: title,
-  instruction: ['If “No” confirm one or more rooms were shared with another household'],
+  instruction: instruction,
   type: 'General',
   answers: [{
     id: 'self-contained-answer',
@@ -27,11 +27,11 @@ local question(title) = {
   id: 'self-contained',
   question_variants: [
     {
-      question: question('Are all the rooms in this accommodation, including the kitchen, bathroom and toilet, behind a door that only this household can use?'),
+      question: question('Are all the rooms in this accommodation, including the kitchen, bathroom and toilet, behind a door that only this household can use?', ['If “No” confirm one or more rooms are shared with another household']),
       when: [rules.livingAtCurrentAddress],
     },
     {
-      question: question('Were all the rooms in that accommodation, including the kitchen, bathroom and toilet, behind a door that only this household could use?'),
+      question: question('Were all the rooms in that accommodation, including the kitchen, bathroom and toilet, behind a door that only this household could use?', ['If “No” confirm one or more rooms were shared with another household']),
       when: [rules.livingAtDifferentAddress],
     },
   ],

--- a/source/jsonnet/england-wales/ccs/blocks/individual/employment_status.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/individual/employment_status.jsonnet
@@ -1,7 +1,7 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title) = {
+local question(title, description) = {
   id: 'employment-status-question',
   title: title,
   description: [
@@ -23,7 +23,7 @@ local question(title) = {
         {
           label: 'Self-employed or freelance',
           value: 'Self-employed or freelance',
-          description: 'Freelance means that they are self-employed and work for different companies or people on particular pieces of work',
+          description: description,
         },
         {
           label: 'Temporarily away from work ill, on holiday or temporarily laid off',
@@ -68,16 +68,20 @@ local proxyTitle = {
   ],
 };
 
+local nonProxyDescription = 'Freelance means that you are self-employed and work for different companies or people on particular pieces of work';
+
+local proxyDescription = 'Freelance means that they are self-employed and work for different companies or people on particular pieces of work';
+
 {
   type: 'Question',
   id: 'employment-status',
   question_variants: [
     {
-      question: question(nonProxyTitle),
+      question: question(nonProxyTitle, nonProxyDescription),
       when: [rules.isNotProxy],
     },
     {
-      question: question(proxyTitle),
+      question: question(proxyTitle, proxyDescription),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/anyone_else_list_collector.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/anyone_else_list_collector.jsonnet
@@ -137,7 +137,7 @@ local editQuestion(questionTitle) = {
             title: 'Electronic Showcard',
             contents: [
               {
-                description: 'Include',
+                description: '<strong>Include</strong>',
               },
               {
                 list: [

--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/anyone_else_temp_away_list_collector.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/anyone_else_temp_away_list_collector.jsonnet
@@ -76,7 +76,7 @@ local editQuestion(questionTitle) = {
             ],
           },
           {
-            description: '<strong>Include people temporarily staying on such as</strong>',
+            description: '<strong>Include people temporarily staying such as</strong>',
           },
           {
             list: [
@@ -155,11 +155,7 @@ local editQuestion(questionTitle) = {
     question: {
       id: 'anyone-else-temp-away-remove-question',
       type: 'General',
-      guidance: {
-        contents: [{
-          title: 'All of the data entered about this person will be deleted',
-        }],
-      },
+      warning: 'All of the information entered about this person will be deleted',
       title: {
         text: 'Are you sure you want to remove <em>{person_name}</em>?',
         placeholders: [

--- a/source/jsonnet/england-wales/ccs/blocks/who-lives-here/usual_address.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/who-lives-here/usual_address.jsonnet
@@ -27,12 +27,6 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
         type: 'TextField',
       },
       {
-        id: 'usual-address-answer-county',
-        label: 'County',
-        mandatory: false,
-        type: 'TextField',
-      },
-      {
         id: 'usual-address-answer-postcode',
         label: 'Postcode',
         mandatory: false,

--- a/translations/ccs_household_gb_wls.pot
+++ b/translations/ccs_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-22 16:11+0100\n"
+"POT-Creation-Date: 2020-07-24 08:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -784,7 +784,7 @@ msgstr ""
 msgctxt ""
 "Are all the rooms in this accommodation, including the kitchen, bathroom "
 "and toilet, behind a door that only this household can use?"
-msgid "If “No” confirm one or more rooms were shared with another household"
+msgid "If “No” confirm one or more rooms are shared with another household"
 msgstr ""
 
 #. Question instruction
@@ -1093,11 +1093,6 @@ msgid "<strong>Include</strong>"
 msgstr ""
 
 #. Question definition description
-msgctxt "Did anyone else usually live in your household on Sunday {census_date}?"
-msgid "Include"
-msgstr ""
-
-#. Question definition description
 msgctxt ""
 "Apart from the people already included, is there anyone else who was "
 "temporarily away or staying that you need to add?"
@@ -1108,7 +1103,7 @@ msgstr ""
 msgctxt ""
 "Apart from the people already included, is there anyone else who was "
 "temporarily away or staying that you need to add?"
-msgid "<strong>Include people temporarily staying on such as</strong>"
+msgid "<strong>Include people temporarily staying such as</strong>"
 msgstr ""
 
 #. Question definition description
@@ -1324,11 +1319,6 @@ msgctxt ""
 msgid "there were no visitors staying overnight on {census_date}"
 msgstr ""
 
-#. Question guidance heading
-msgctxt "Are you sure you want to remove <em>{person_name}</em>?"
-msgid "All of the data entered about this person will be deleted"
-msgstr ""
-
 #. Answer
 msgctxt "What is your full name?"
 msgid "First name"
@@ -1357,11 +1347,6 @@ msgstr ""
 #. Answer
 msgctxt "What was your household’s usual address?"
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt "What was your household’s usual address?"
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -3076,7 +3061,7 @@ msgstr ""
 msgctxt ""
 "In the last year, how have you or your household used online government "
 "services?"
-msgid "For example, passports, driving licence"
+msgid "For example, passport, driving licence"
 msgstr ""
 
 #. Answer option description
@@ -3235,7 +3220,7 @@ msgctxt ""
 "During the week of 15 to {census_date}, were you doing any of the "
 "following?"
 msgid ""
-"Freelance means that they are self-employed and work for different "
+"Freelance means that you are self-employed and work for different "
 "companies or people on particular pieces of work"
 msgstr ""
 


### PR DESCRIPTION
### What is the context of this PR?

Content mop up updates for CSS as described on [this Trello card](https://trello.com/c/ZEaMfKAz).

### How to review

Check the changes match the [google doc](https://docs.google.com/spreadsheets/d/1JZDyX0RS2nkZj5A4kXvxubdGr_BV2Hk6XGnSRq6AClA/edit#gid=1275715253).

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/ccs-qa-mop-up-2/schemas/en/ccs_household_gb_eng.json)
