### PR TITLE
QA Content Changes II

### DIFF
--- a/source/jsonnet/england-wales/household/blocks/individual/location_one_year_ago.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/individual/location_one_year_ago.jsonnet
@@ -43,14 +43,15 @@ local question(title, description, additionalAnswerOptions=[]) = {
 };
 
 local nonProxyTitle = 'One year ago, what was your usual address?';
-local nonProxyDescription = 'If you had no usual address one year ago, state the address where you were staying';
+local nonProxyDescription = 'If you had no usual address one year ago, select the address where you were staying';
+
 local proxyTitle = {
   text: 'One year ago, what was <em>{person_name_possessive}</em> usual address?',
   placeholders: [
     placeholders.personNamePossessive,
   ],
 };
-local proxyDescription = 'If they had no usual address one year ago, state the address where they were staying';
+local proxyDescription = 'If they had no usual address one year ago, select the address where they were staying';
 
 local additionalAnswerOption = [
   {

--- a/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_details.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_details.jsonnet
@@ -34,12 +34,6 @@ local rules = import 'rules.libsonnet';
         type: 'TextField',
       },
       {
-        id: 'visitor-usual-address-details-answer-county',
-        label: 'County (optional)',
-        mandatory: false,
-        type: 'TextField',
-      },
-      {
         id: 'visitor-usual-address-details-answer-postcode',
         label: 'Postcode',
         mandatory: false,

--- a/source/jsonnet/england-wales/individual/blocks/employment/business_type.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/business_type.jsonnet
@@ -17,8 +17,8 @@ local pastProxyTitle = {
   ],
 };
 
-local englandDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service DWP, local government housing.';
-local walesDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service (Welsh Government), local government (housing).';
+local englandDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service DWP, local government housing';
+local walesDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service (Welsh Government), local government (housing)';
 
 local question(title, region_code) = (
   local description = if region_code == 'GB-WLS' then walesDescription else englandDescription;

--- a/source/jsonnet/england-wales/individual/blocks/employment/depot_address.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/depot_address.jsonnet
@@ -25,12 +25,6 @@ local question(title, guidanceHeader, guidanceContent) = {
       type: 'TextField',
     },
     {
-      id: 'depot-address-answer-county',
-      label: 'County',
-      mandatory: false,
-      type: 'TextField',
-    },
-    {
       id: 'depot-address-answer-postcode',
       label: 'Postcode',
       mandatory: false,

--- a/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
@@ -18,7 +18,7 @@ local question(title) = {
   ],
 };
 
-local nonProxyTitle = 'Which country outside the UK do you mainly work in?';
+local nonProxyTitle = 'In which country outside the UK do you mainly work?';
 local proxyTitle = {
   text: 'In which country outside the UK does <em>{person_name}</em> mainly work?',
   placeholders: [

--- a/source/jsonnet/england-wales/individual/blocks/employment/workplace_address.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/workplace_address.jsonnet
@@ -25,12 +25,6 @@ local question(title, guidanceHeader, guidanceContent) = {
       type: 'TextField',
     },
     {
-      id: 'workplace-address-answer-county',
-      label: 'County',
-      mandatory: false,
-      type: 'TextField',
-    },
-    {
       id: 'workplace-address-answer-postcode',
       label: 'Postcode',
       mandatory: false,

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago.jsonnet
@@ -25,12 +25,6 @@ local question(title) = {
       type: 'TextField',
     },
     {
-      id: 'address-one-year-ago-answer-county',
-      label: 'County',
-      mandatory: false,
-      type: 'TextField',
-    },
-    {
       id: 'address-one-year-ago-answer-postcode',
       label: 'Postcode',
       mandatory: false,

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
@@ -3,8 +3,8 @@ local rules = import 'rules.libsonnet';
 
 local question(englandTitle, walesTitle, region_code) = (
   local title = if region_code == 'GB-WLS' then walesTitle else englandTitle;
-  local label = if region_code == 'GB-WLS' then 'Black, Black Welsh, Black British or Caribbean background'
-  else 'Black, Black British or Caribbean background';
+  local label = if region_code == 'GB-WLS' then 'Black, Black Welsh, Black British or Caribbean ethnic group or background'
+  else 'Black, Black British or Caribbean ethnic group or background';
   {
     id: 'other-black-black-british-caribbean-or-african-ethnic-group-question',
     title: title,

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_mixed_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_mixed_other.jsonnet
@@ -9,7 +9,6 @@ local question(title) = {
     {
       id: 'other-mixed-or-multiple-ethnic-group-answer',
       label: 'Mixed or Multiple ethnic group or background',
-      description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
       type: 'TextField',

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'ethnic-group-other-other-answer',
-      label: 'Ethnic group',
+      label: 'Ethnic group or background',
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -7,7 +7,9 @@ local question(title, guidance) = {
   type: 'General',
   guidance: {
     contents: [
-      guidance,
+      {
+        description: guidance,
+      },
     ],
   },
   answers: [

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -1,10 +1,15 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title) = {
+local question(title, guidance) = {
   id: 'other-national-identities-question',
   title: title,
   type: 'General',
+  guidance: {
+    contents: [
+      guidance,
+    ],
+  },
   answers: [
     {
       id: 'other-national-identities-answer',
@@ -23,16 +28,22 @@ local question(title) = {
   id: 'other-national-identities',
   question_variants: [
     {
-      question: question('You selected “Other”. How would you describe your other national identity?'),
+      question: question(
+        'You selected “Other”. How would you describe your other national identity?',
+        'Include all other national identities. If you have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isNotProxy],
     },
     {
-      question: question({
-        text: 'You selected “Other”. How would <em>{person_name}</em> describe their other national identity?',
-        placeholders: [
-          placeholders.personName,
-        ],
-      }),
+      question: question(
+        {
+          text: 'You selected “Other”. How would <em>{person_name}</em> describe their other national identity?',
+          placeholders: [
+            placeholders.personName,
+          ],
+        },
+        'Include all other national identities. If they have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -7,7 +7,9 @@ local question(title, guidance) = {
   type: 'General',
   guidance: {
     contents: [
-      guidance,
+      {
+        description: guidance,
+      },
     ],
   },
   answers: [

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -1,10 +1,15 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title) = {
+local question(title, guidance) = {
   id: 'other-national-identity-question',
   title: title,
   type: 'General',
+  guidance: {
+    contents: [
+      guidance,
+    ],
+  },
   answers: [
     {
       id: 'other-national-identity-answer',
@@ -23,16 +28,22 @@ local question(title) = {
   id: 'other-national-identity',
   question_variants: [
     {
-      question: question('You selected “Other”. How would you describe your national identity?'),
+      question: question(
+        'You selected “Other”. How would you describe your national identity?',
+        'Include all national identities. If you have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isNotProxy],
     },
     {
-      question: question({
-        text: 'You selected “Other”. How would <em>{person_name}</em> describe their national identity?',
-        placeholders: [
-          placeholders.personName,
-        ],
-      }),
+      question: question(
+        {
+          text: 'You selected “Other”. How would <em>{person_name}</em> describe their national identity?',
+          placeholders: [
+            placeholders.personName,
+          ],
+        },
+        'Include all national identities. If they have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports.jsonnet
@@ -1,7 +1,7 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title, description, otherDescription) = {
+local question(title, description) = {
   id: 'passports-question',
   title: title,
   type: 'MutuallyExclusive',
@@ -34,7 +34,7 @@ local question(title, description, otherDescription) = {
         {
           label: 'Other',
           value: 'Other',
-          description: otherDescription,
+          description: 'You can enter these passports on the next question',
         },
       ],
     },
@@ -67,11 +67,11 @@ local proxyLabel = 'Enter passports held';
   id: 'passports',
   question_variants: [
     {
-      question: question(nonProxyTitle, 'passports and travel documents that have expired, if you are entitled to renew them', 'You can enter your passports on the next question'),
+      question: question(nonProxyTitle, 'passports and travel documents that have expired, if you are entitled to renew them'),
       when: [rules.isNotProxy],
     },
     {
-      question: question(proxyTitle, 'passports and travel documents that have expired, if they are entitled to renew them', 'You can enter their passports on the next question'),
+      question: question(proxyTitle, 'passports and travel documents that have expired, if they are entitled to renew them'),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -7,7 +7,9 @@ local question(title, guidance) = {
   type: 'General',
   guidance: {
     contents: [
-      guidance,
+      {
+        description: guidance,
+      },
     ],
   },
   answers: [

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -1,10 +1,15 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title) = {
+local question(title, guidance) = {
   id: 'passports-additional-other-question',
   title: title,
   type: 'General',
+  guidance: {
+    contents: [
+      guidance,
+    ],
+  },
   answers: [
     {
       id: 'passports-additional-other-answer',
@@ -23,16 +28,22 @@ local question(title) = {
   id: 'passports-additional-other',
   question_variants: [
     {
-      question: question('You selected “Other”. What other passports do you hold?'),
+      question: question(
+        'You selected “Other”. What other passports do you hold?',
+        'Include all other passports. If you have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isNotProxy],
     },
     {
-      question: question({
-        text: 'You selected “Other”. What other passports does <em>{person_name}</em> hold?',
-        placeholders: [
-          placeholders.personName,
-        ],
-      }),
+      question: question(
+        {
+          text: 'You selected “Other”. What other passports does <em>{person_name}</em> hold?',
+          placeholders: [
+            placeholders.personName,
+          ],
+        },
+        'Include all other passports. If they have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -7,7 +7,9 @@ local question(title, guidance) = {
   type: 'General',
   guidance: {
     contents: [
-      guidance,
+      {
+        description: guidance,
+      },
     ],
   },
   answers: [
@@ -28,17 +30,22 @@ local question(title, guidance) = {
   id: 'passports-other',
   question_variants: [
     {
-      question: question('You selected “Other”. What passports do you hold?', 'Include all passports. If you have more than one, enter them all separated by commas.'),
+      question: question(
+        'You selected “Other”. What passports do you hold?',
+        'Include all passports. If you have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isNotProxy],
     },
     {
-      question: question({
-                           text: 'You selected “Other”. What passports does <em>{person_name}</em> hold?',
-                           placeholders: [
-                             placeholders.personName,
-                           ],
-                         },
-                         'Include all passports. If they have more than one, enter them all separated by commas.'),
+      question: question(
+        {
+          text: 'You selected “Other”. What passports does <em>{person_name}</em> hold?',
+          placeholders: [
+            placeholders.personName,
+          ],
+        },
+        'Include all passports. If they have more than one, enter them all separated by commas.'
+      ),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -1,10 +1,15 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title) = {
+local question(title, guidance) = {
   id: 'passports-other-question',
   title: title,
   type: 'General',
+  guidance: {
+    contents: [
+      guidance,
+    ],
+  },
   answers: [
     {
       id: 'passports-other-answer',
@@ -23,16 +28,17 @@ local question(title) = {
   id: 'passports-other',
   question_variants: [
     {
-      question: question('You selected “Other”. What passports do you hold?'),
+      question: question('You selected “Other”. What passports do you hold?', 'Include all passports. If you have more than one, enter them all separated by commas.'),
       when: [rules.isNotProxy],
     },
     {
       question: question({
-        text: 'You selected “Other”. What passports does <em>{person_name}</em> hold?',
-        placeholders: [
-          placeholders.personName,
-        ],
-      }),
+                           text: 'You selected “Other”. What passports does <em>{person_name}</em> hold?',
+                           placeholders: [
+                             placeholders.personName,
+                           ],
+                         },
+                         'Include all passports. If they have more than one, enter them all separated by commas.'),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_orientation.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/sexual_orientation.jsonnet
@@ -25,7 +25,7 @@ local question(title, guidanceHeader, description) = {
             description: description,
           },
           {
-            description: 'Councils and government will use this information to:',
+            description: 'Councils and government will use this information to',
             list: [
               'monitor equality to ensure that everyone is treated fairly',
               'provide services and share funding',

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/other_address_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/other_address_uk.jsonnet
@@ -30,12 +30,6 @@ local question(title) = {
       type: 'TextField',
     },
     {
-      id: 'other-address-uk-answer-county',
-      label: 'County',
-      mandatory: false,
-      type: 'TextField',
-    },
-    {
       id: 'other-address-uk-answer-postcode',
       label: 'Postcode',
       mandatory: false,

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_uk.jsonnet
@@ -25,12 +25,6 @@ local question(title) = {
       type: 'TextField',
     },
     {
-      id: 'term-time-address-uk-answer-county',
-      label: 'County',
-      mandatory: false,
-      type: 'TextField',
-    },
-    {
       id: 'term-time-address-uk-answer-postcode',
       label: 'Postcode',
       mandatory: false,

--- a/source/jsonnet/england-wales/individual/blocks/qualifications/gcse.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/qualifications/gcse.jsonnet
@@ -72,8 +72,8 @@ local question(region_code, isProxy) = (
         type: 'Checkbox',
         options: [
           {
-            label: '5 or more GCSEs grades A* to C or 9 to 4',
-            value: '5 or more GCSEs grades A* to C or 9 to 4',
+            label: '5 or more GCSEs grade A* to C or 9 to 4',
+            value: '5 or more GCSEs grade A* to C or 9 to 4',
             description: 'Include 5 or more O level passes or CSEs grades 1',
           },
           {

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-24 15:08+0100\n"
+"POT-Creation-Date: 2020-07-27 16:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1349,7 +1349,7 @@ msgid "What is the address of <em>{person_name_possessive}</em> depot?"
 msgstr ""
 
 #. Question text
-msgid "Which country outside the UK do you mainly work in?"
+msgid "In which country outside the UK do you mainly work?"
 msgstr ""
 
 #. Question text
@@ -1428,14 +1428,14 @@ msgstr ""
 #. Question description
 msgctxt "One year ago, what was your usual address?"
 msgid ""
-"If you had no usual address one year ago, state the address where you "
+"If you had no usual address one year ago, select the address where you "
 "were staying"
 msgstr ""
 
 #. Question description
 msgctxt "One year ago, what was <em>{person_name_possessive}</em> usual address?"
 msgid ""
-"If they had no usual address one year ago, state the address where they "
+"If they had no usual address one year ago, select the address where they "
 "were staying"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgctxt ""
 "work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -1639,7 +1639,7 @@ msgctxt ""
 "organisation, business or freelance work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -1648,7 +1648,7 @@ msgctxt ""
 "work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -1657,7 +1657,7 @@ msgctxt ""
 "organisation, business or freelance work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -2295,6 +2295,38 @@ msgid "A question about gender identity will follow later on in the questionnair
 msgstr ""
 
 #. Question guidance description
+msgctxt "You selected “Other”. How would you describe your national identity?"
+msgid ""
+"Include all national identities. If you have more than one, enter them "
+"all separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt ""
+"You selected “Other”. How would <em>{person_name}</em> describe their "
+"national identity?"
+msgid ""
+"Include all national identities. If they have more than one, enter them "
+"all separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. How would you describe your other national identity?"
+msgid ""
+"Include all other national identities. If you have more than one, enter "
+"them all separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt ""
+"You selected “Other”. How would <em>{person_name}</em> describe their "
+"other national identity?"
+msgid ""
+"Include all other national identities. If they have more than one, enter "
+"them all separated by commas."
+msgstr ""
+
+#. Question guidance description
 msgctxt "What is your religion?"
 msgid "This question is <strong>voluntary</strong>"
 msgstr ""
@@ -2314,6 +2346,36 @@ msgctxt ""
 "You selected “Any other religion”. What is "
 "<em>{person_name_possessive}</em> religion?"
 msgid "This question is <strong>voluntary</strong>"
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. What passports do you hold?"
+msgid ""
+"Include all passports. If you have more than one, enter them all "
+"separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. What passports does <em>{person_name}</em> hold?"
+msgid ""
+"Include all passports. If they have more than one, enter them all "
+"separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. What other passports do you hold?"
+msgid ""
+"Include all other passports. If you have more than one, enter them all "
+"separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt ""
+"You selected “Other”. What other passports does <em>{person_name}</em> "
+"hold?"
+msgid ""
+"Include all other passports. If they have more than one, enter them all "
+"separated by commas."
 msgstr ""
 
 #. Question guidance description
@@ -2795,13 +2857,6 @@ msgstr ""
 msgctxt ""
 "Enter details of the other UK address where you stay for more than 30 "
 "days a year."
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt ""
-"Enter details of the other UK address where you stay for more than 30 "
-"days a year."
 msgid "Postcode"
 msgstr ""
 
@@ -2824,13 +2879,6 @@ msgctxt ""
 "Enter details of the other UK address where <em>{person_name}</em> stays "
 "for more than 30 days a year."
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt ""
-"Enter details of the other UK address where <em>{person_name}</em> stays "
-"for more than 30 days a year."
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -2869,11 +2917,6 @@ msgstr ""
 
 #. Answer
 msgctxt "Enter details of the UK address where you usually stay during term time."
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "Enter details of the UK address where you usually stay during term time."
 msgid "Postcode"
 msgstr ""
 
@@ -2896,13 +2939,6 @@ msgctxt ""
 "Enter details of the UK address where <em>{person_name}</em> usually "
 "stays during term time."
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt ""
-"Enter details of the UK address where <em>{person_name}</em> usually "
-"stays during term time."
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -2953,11 +2989,6 @@ msgstr ""
 
 #. Answer
 msgctxt "Enter details of your address one year ago."
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "Enter details of your address one year ago."
 msgid "Postcode"
 msgstr ""
 
@@ -2974,11 +3005,6 @@ msgstr ""
 #. Answer
 msgctxt "Enter details of <em>{person_name_possessive}</em> address one year ago."
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt "Enter details of <em>{person_name_possessive}</em> address one year ago."
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -3073,7 +3099,7 @@ msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would you describe your Black, Black British or "
 "Caribbean background?"
-msgid "Black, Black Welsh, Black British or Caribbean background"
+msgid "Black, Black Welsh, Black British or Caribbean ethnic group or background"
 msgstr ""
 
 #. Answer
@@ -3081,21 +3107,21 @@ msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would <em>{person_name}</em> describe their Black, Black"
 " British or Caribbean ethnic group or background?"
-msgid "Black, Black Welsh, Black British or Caribbean background"
+msgid "Black, Black Welsh, Black British or Caribbean ethnic group or background"
 msgstr ""
 
 #. Answer
 msgctxt ""
 "You selected “Any other ethnic group”. How would you describe your ethnic"
 " group or background?"
-msgid "Ethnic group"
+msgid "Ethnic group or background"
 msgstr ""
 
 #. Answer
 msgctxt ""
 "You selected “Any other ethnic group”. How would <em>{person_name}</em> "
 "describe their ethnic group or background?"
-msgid "Ethnic group"
+msgid "Ethnic group or background"
 msgstr ""
 
 #. Answer
@@ -3255,11 +3281,6 @@ msgstr ""
 
 #. Answer
 msgctxt "What is the address of your workplace?"
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of your workplace?"
 msgid "Postcode"
 msgstr ""
 
@@ -3276,11 +3297,6 @@ msgstr ""
 #. Answer
 msgctxt "What is the address of <em>{person_name_possessive}</em> workplace?"
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of <em>{person_name_possessive}</em> workplace?"
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -3305,11 +3321,6 @@ msgstr ""
 
 #. Answer
 msgctxt "What is the address of your depot?"
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of your depot?"
 msgid "Postcode"
 msgstr ""
 
@@ -3330,16 +3341,11 @@ msgstr ""
 
 #. Answer
 msgctxt "What is the address of <em>{person_name_possessive}</em> depot?"
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of <em>{person_name_possessive}</em> depot?"
 msgid "Postcode"
 msgstr ""
 
 #. Answer
-msgctxt "Which country outside the UK do you mainly work in?"
+msgctxt "In which country outside the UK do you mainly work?"
 msgid "Current name of country"
 msgstr ""
 
@@ -3361,11 +3367,6 @@ msgstr ""
 #. Answer
 msgctxt "Enter details of <em>{person_name_possessive}</em> usual UK address"
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt "Enter details of <em>{person_name_possessive}</em> usual UK address"
-msgid "County (optional)"
 msgstr ""
 
 #. Answer
@@ -3481,23 +3482,6 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Mixed or Multiple ethnic group or background
-msgctxt ""
-"You selected “Any other Mixed or Multiple background”. How would you "
-"describe your Mixed or Multiple ethnic group or background?"
-msgid "Enter your own answer or select from suggestions"
-msgstr ""
-
-#. Answer description
-#. For answer: Mixed or Multiple ethnic group or background
-msgctxt ""
-"You selected “Any other Mixed or Multiple background”. How would "
-"<em>{person_name}</em> describe their Mixed or Multiple ethnic group or "
-"background?"
-msgid "Enter your own answer or select from suggestions"
-msgstr ""
-
-#. Answer description
 #. For answer: Asian, Asian Welsh or Asian British ethnic group or background
 msgctxt ""
 "You selected “Any other Asian background”. How would you describe your "
@@ -3531,7 +3515,8 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Black, Black Welsh, Black British or Caribbean background
+#. For answer: Black, Black Welsh, Black British or Caribbean ethnic group or
+#. background
 msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would you describe your Black, Black British or "
@@ -3540,7 +3525,8 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Black, Black Welsh, Black British or Caribbean background
+#. For answer: Black, Black Welsh, Black British or Caribbean ethnic group or
+#. background
 msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would <em>{person_name}</em> describe their Black, Black"
@@ -3549,7 +3535,7 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Ethnic group
+#. For answer: Ethnic group or background
 msgctxt ""
 "You selected “Any other ethnic group”. How would you describe your ethnic"
 " group or background?"
@@ -3557,7 +3543,7 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Ethnic group
+#. For answer: Ethnic group or background
 msgctxt ""
 "You selected “Any other ethnic group”. How would <em>{person_name}</em> "
 "describe their ethnic group or background?"
@@ -3622,7 +3608,7 @@ msgstr ""
 
 #. Answer description
 #. For answer: Current name of country
-msgctxt "Which country outside the UK do you mainly work in?"
+msgctxt "In which country outside the UK do you mainly work?"
 msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
@@ -5928,7 +5914,7 @@ msgstr ""
 
 #. Answer option
 msgctxt "Have you achieved a GCSE or equivalent qualification?"
-msgid "5 or more GCSEs grades A* to C or 9 to 4"
+msgid "5 or more GCSEs grade A* to C or 9 to 4"
 msgstr ""
 
 #. Answer option
@@ -5958,7 +5944,7 @@ msgstr ""
 
 #. Answer option
 msgctxt "Has <em>{person_name}</em> achieved a GCSE or equivalent qualification?"
-msgid "5 or more GCSEs grades A* to C or 9 to 4"
+msgid "5 or more GCSEs grade A* to C or 9 to 4"
 msgstr ""
 
 #. Answer option
@@ -7068,13 +7054,13 @@ msgstr ""
 #. Answer option description
 #. For answer option: Other
 msgctxt "What passports do you hold?"
-msgid "You can enter your passports on the next question"
+msgid "You can enter these passports on the next question"
 msgstr ""
 
 #. Answer option description
 #. For answer option: Other
 msgctxt "What passports does <em>{person_name}</em> hold?"
-msgid "You can enter their passports on the next question"
+msgid "You can enter these passports on the next question"
 msgstr ""
 
 #. Answer option description
@@ -7200,7 +7186,7 @@ msgid "Questions on GCSEs and equivalents will follow"
 msgstr ""
 
 #. Answer option description
-#. For answer option: 5 or more GCSEs grades A* to C or 9 to 4
+#. For answer option: 5 or more GCSEs grade A* to C or 9 to 4
 msgctxt "Have you achieved a GCSE or equivalent qualification?"
 msgid "Include 5 or more O level passes or CSEs grades 1"
 msgstr ""
@@ -7218,7 +7204,7 @@ msgid "Skills for life, literacy, numeracy and language"
 msgstr ""
 
 #. Answer option description
-#. For answer option: 5 or more GCSEs grades A* to C or 9 to 4
+#. For answer option: 5 or more GCSEs grade A* to C or 9 to 4
 msgctxt "Has <em>{person_name}</em> achieved a GCSE or equivalent qualification?"
 msgid "Include 5 or more O level passes or CSEs grades 1"
 msgstr ""
@@ -8083,7 +8069,7 @@ msgstr ""
 
 #. Answer guidance description
 msgctxt "Which of the following best describes your sexual orientation?"
-msgid "Councils and government will use this information to:"
+msgid "Councils and government will use this information to"
 msgstr ""
 
 #. Answer guidance description
@@ -8100,7 +8086,7 @@ msgstr ""
 msgctxt ""
 "Which of the following best describes <em>{person_name_possessive}</em> "
 "sexual orientation?"
-msgid "Councils and government will use this information to:"
+msgid "Councils and government will use this information to"
 msgstr ""
 
 #. Answer guidance description
@@ -8578,19 +8564,19 @@ msgid "understand and represent everyone’s interests"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt "Which of the following best describes your sexual orientation?"
 msgid "monitor equality to ensure that everyone is treated fairly"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt "Which of the following best describes your sexual orientation?"
 msgid "provide services and share funding"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt ""
 "Which of the following best describes <em>{person_name_possessive}</em> "
 "sexual orientation?"
@@ -8598,7 +8584,7 @@ msgid "monitor equality to ensure that everyone is treated fairly"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt ""
 "Which of the following best describes <em>{person_name_possessive}</em> "
 "sexual orientation?"

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-20 17:41+0100\n"
+"POT-Creation-Date: 2020-07-27 16:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -987,7 +987,7 @@ msgid "What is the address of <em>{person_name_possessive}</em> depot?"
 msgstr ""
 
 #. Question text
-msgid "Which country outside the UK do you mainly work in?"
+msgid "In which country outside the UK do you mainly work?"
 msgstr ""
 
 #. Question text
@@ -1237,7 +1237,7 @@ msgctxt ""
 "work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -1246,7 +1246,7 @@ msgctxt ""
 "organisation, business or freelance work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -1255,7 +1255,7 @@ msgctxt ""
 "work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -1264,7 +1264,7 @@ msgctxt ""
 "organisation, business or freelance work?"
 msgid ""
 "For example, clothing retail, general hospital, primary education, food "
-"wholesale, civil service (Welsh Government), local government (housing)."
+"wholesale, civil service (Welsh Government), local government (housing)"
 msgstr ""
 
 #. Question description
@@ -1726,6 +1726,38 @@ msgid "A question about gender identity will follow later on in the questionnair
 msgstr ""
 
 #. Question guidance description
+msgctxt "You selected “Other”. How would you describe your national identity?"
+msgid ""
+"Include all national identities. If you have more than one, enter them "
+"all separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt ""
+"You selected “Other”. How would <em>{person_name}</em> describe their "
+"national identity?"
+msgid ""
+"Include all national identities. If they have more than one, enter them "
+"all separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. How would you describe your other national identity?"
+msgid ""
+"Include all other national identities. If you have more than one, enter "
+"them all separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt ""
+"You selected “Other”. How would <em>{person_name}</em> describe their "
+"other national identity?"
+msgid ""
+"Include all other national identities. If they have more than one, enter "
+"them all separated by commas."
+msgstr ""
+
+#. Question guidance description
 msgctxt "What is your religion?"
 msgid "This question is <strong>voluntary</strong>"
 msgstr ""
@@ -1745,6 +1777,36 @@ msgctxt ""
 "You selected “Any other religion”. What is "
 "<em>{person_name_possessive}</em> religion?"
 msgid "This question is <strong>voluntary</strong>"
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. What passports do you hold?"
+msgid ""
+"Include all passports. If you have more than one, enter them all "
+"separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. What passports does <em>{person_name}</em> hold?"
+msgid ""
+"Include all passports. If they have more than one, enter them all "
+"separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt "You selected “Other”. What other passports do you hold?"
+msgid ""
+"Include all other passports. If you have more than one, enter them all "
+"separated by commas."
+msgstr ""
+
+#. Question guidance description
+msgctxt ""
+"You selected “Other”. What other passports does <em>{person_name}</em> "
+"hold?"
+msgid ""
+"Include all other passports. If they have more than one, enter them all "
+"separated by commas."
 msgstr ""
 
 #. Question guidance description
@@ -1992,13 +2054,6 @@ msgstr ""
 msgctxt ""
 "Enter details of the other UK address where you stay for more than 30 "
 "days a year."
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt ""
-"Enter details of the other UK address where you stay for more than 30 "
-"days a year."
 msgid "Postcode"
 msgstr ""
 
@@ -2021,13 +2076,6 @@ msgctxt ""
 "Enter details of the other UK address where <em>{person_name}</em> stays "
 "for more than 30 days a year."
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt ""
-"Enter details of the other UK address where <em>{person_name}</em> stays "
-"for more than 30 days a year."
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -2066,11 +2114,6 @@ msgstr ""
 
 #. Answer
 msgctxt "Enter details of the UK address where you usually stay during term time."
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "Enter details of the UK address where you usually stay during term time."
 msgid "Postcode"
 msgstr ""
 
@@ -2093,13 +2136,6 @@ msgctxt ""
 "Enter details of the UK address where <em>{person_name}</em> usually "
 "stays during term time."
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt ""
-"Enter details of the UK address where <em>{person_name}</em> usually "
-"stays during term time."
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -2150,11 +2186,6 @@ msgstr ""
 
 #. Answer
 msgctxt "Enter details of your address one year ago."
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "Enter details of your address one year ago."
 msgid "Postcode"
 msgstr ""
 
@@ -2171,11 +2202,6 @@ msgstr ""
 #. Answer
 msgctxt "Enter details of <em>{person_name_possessive}</em> address one year ago."
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt "Enter details of <em>{person_name_possessive}</em> address one year ago."
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -2270,7 +2296,7 @@ msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would you describe your Black, Black British or "
 "Caribbean background?"
-msgid "Black, Black Welsh, Black British or Caribbean background"
+msgid "Black, Black Welsh, Black British or Caribbean ethnic group or background"
 msgstr ""
 
 #. Answer
@@ -2278,21 +2304,21 @@ msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would <em>{person_name}</em> describe their Black, Black"
 " British or Caribbean ethnic group or background?"
-msgid "Black, Black Welsh, Black British or Caribbean background"
+msgid "Black, Black Welsh, Black British or Caribbean ethnic group or background"
 msgstr ""
 
 #. Answer
 msgctxt ""
 "You selected “Any other ethnic group”. How would you describe your ethnic"
 " group or background?"
-msgid "Ethnic group"
+msgid "Ethnic group or background"
 msgstr ""
 
 #. Answer
 msgctxt ""
 "You selected “Any other ethnic group”. How would <em>{person_name}</em> "
 "describe their ethnic group or background?"
-msgid "Ethnic group"
+msgid "Ethnic group or background"
 msgstr ""
 
 #. Answer
@@ -2452,11 +2478,6 @@ msgstr ""
 
 #. Answer
 msgctxt "What is the address of your workplace?"
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of your workplace?"
 msgid "Postcode"
 msgstr ""
 
@@ -2473,11 +2494,6 @@ msgstr ""
 #. Answer
 msgctxt "What is the address of <em>{person_name_possessive}</em> workplace?"
 msgid "Town or city"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of <em>{person_name_possessive}</em> workplace?"
-msgid "County"
 msgstr ""
 
 #. Answer
@@ -2502,11 +2518,6 @@ msgstr ""
 
 #. Answer
 msgctxt "What is the address of your depot?"
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of your depot?"
 msgid "Postcode"
 msgstr ""
 
@@ -2527,16 +2538,11 @@ msgstr ""
 
 #. Answer
 msgctxt "What is the address of <em>{person_name_possessive}</em> depot?"
-msgid "County"
-msgstr ""
-
-#. Answer
-msgctxt "What is the address of <em>{person_name_possessive}</em> depot?"
 msgid "Postcode"
 msgstr ""
 
 #. Answer
-msgctxt "Which country outside the UK do you mainly work in?"
+msgctxt "In which country outside the UK do you mainly work?"
 msgid "Current name of country"
 msgstr ""
 
@@ -2648,23 +2654,6 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Mixed or Multiple ethnic group or background
-msgctxt ""
-"You selected “Any other Mixed or Multiple background”. How would you "
-"describe your Mixed or Multiple ethnic group or background?"
-msgid "Enter your own answer or select from suggestions"
-msgstr ""
-
-#. Answer description
-#. For answer: Mixed or Multiple ethnic group or background
-msgctxt ""
-"You selected “Any other Mixed or Multiple background”. How would "
-"<em>{person_name}</em> describe their Mixed or Multiple ethnic group or "
-"background?"
-msgid "Enter your own answer or select from suggestions"
-msgstr ""
-
-#. Answer description
 #. For answer: Asian, Asian Welsh or Asian British ethnic group or background
 msgctxt ""
 "You selected “Any other Asian background”. How would you describe your "
@@ -2698,7 +2687,8 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Black, Black Welsh, Black British or Caribbean background
+#. For answer: Black, Black Welsh, Black British or Caribbean ethnic group or
+#. background
 msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would you describe your Black, Black British or "
@@ -2707,7 +2697,8 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Black, Black Welsh, Black British or Caribbean background
+#. For answer: Black, Black Welsh, Black British or Caribbean ethnic group or
+#. background
 msgctxt ""
 "You selected “Any other Black, Black Welsh, Black British or Caribbean "
 "background”. How would <em>{person_name}</em> describe their Black, Black"
@@ -2716,7 +2707,7 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Ethnic group
+#. For answer: Ethnic group or background
 msgctxt ""
 "You selected “Any other ethnic group”. How would you describe your ethnic"
 " group or background?"
@@ -2724,7 +2715,7 @@ msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
 #. Answer description
-#. For answer: Ethnic group
+#. For answer: Ethnic group or background
 msgctxt ""
 "You selected “Any other ethnic group”. How would <em>{person_name}</em> "
 "describe their ethnic group or background?"
@@ -2789,7 +2780,7 @@ msgstr ""
 
 #. Answer description
 #. For answer: Current name of country
-msgctxt "Which country outside the UK do you mainly work in?"
+msgctxt "In which country outside the UK do you mainly work?"
 msgid "Enter your own answer or select from suggestions"
 msgstr ""
 
@@ -4545,7 +4536,7 @@ msgstr ""
 
 #. Answer option
 msgctxt "Have you achieved a GCSE or equivalent qualification?"
-msgid "5 or more GCSEs grades A* to C or 9 to 4"
+msgid "5 or more GCSEs grade A* to C or 9 to 4"
 msgstr ""
 
 #. Answer option
@@ -4575,7 +4566,7 @@ msgstr ""
 
 #. Answer option
 msgctxt "Has <em>{person_name}</em> achieved a GCSE or equivalent qualification?"
-msgid "5 or more GCSEs grades A* to C or 9 to 4"
+msgid "5 or more GCSEs grade A* to C or 9 to 4"
 msgstr ""
 
 #. Answer option
@@ -5534,13 +5525,13 @@ msgstr ""
 #. Answer option description
 #. For answer option: Other
 msgctxt "What passports do you hold?"
-msgid "You can enter your passports on the next question"
+msgid "You can enter these passports on the next question"
 msgstr ""
 
 #. Answer option description
 #. For answer option: Other
 msgctxt "What passports does <em>{person_name}</em> hold?"
-msgid "You can enter their passports on the next question"
+msgid "You can enter these passports on the next question"
 msgstr ""
 
 #. Answer option description
@@ -5666,7 +5657,7 @@ msgid "Questions on GCSEs and equivalents will follow"
 msgstr ""
 
 #. Answer option description
-#. For answer option: 5 or more GCSEs grades A* to C or 9 to 4
+#. For answer option: 5 or more GCSEs grade A* to C or 9 to 4
 msgctxt "Have you achieved a GCSE or equivalent qualification?"
 msgid "Include 5 or more O level passes or CSEs grades 1"
 msgstr ""
@@ -5684,7 +5675,7 @@ msgid "Skills for life, literacy, numeracy and language"
 msgstr ""
 
 #. Answer option description
-#. For answer option: 5 or more GCSEs grades A* to C or 9 to 4
+#. For answer option: 5 or more GCSEs grade A* to C or 9 to 4
 msgctxt "Has <em>{person_name}</em> achieved a GCSE or equivalent qualification?"
 msgid "Include 5 or more O level passes or CSEs grades 1"
 msgstr ""
@@ -6131,7 +6122,7 @@ msgstr ""
 
 #. Answer guidance description
 msgctxt "Which of the following best describes your sexual orientation?"
-msgid "Councils and government will use this information to:"
+msgid "Councils and government will use this information to"
 msgstr ""
 
 #. Answer guidance description
@@ -6148,7 +6139,7 @@ msgstr ""
 msgctxt ""
 "Which of the following best describes <em>{person_name_possessive}</em> "
 "sexual orientation?"
-msgid "Councils and government will use this information to:"
+msgid "Councils and government will use this information to"
 msgstr ""
 
 #. Answer guidance description
@@ -6602,19 +6593,19 @@ msgid "understand and represent everyone’s interests"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt "Which of the following best describes your sexual orientation?"
 msgid "monitor equality to ensure that everyone is treated fairly"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt "Which of the following best describes your sexual orientation?"
 msgid "provide services and share funding"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt ""
 "Which of the following best describes <em>{person_name_possessive}</em> "
 "sexual orientation?"
@@ -6622,7 +6613,7 @@ msgid "monitor equality to ensure that everyone is treated fairly"
 msgstr ""
 
 #. Answer guidance list item
-#. For description: Councils and government will use this information to:
+#. For description: Councils and government will use this information to
 msgctxt ""
 "Which of the following best describes <em>{person_name_possessive}</em> "
 "sexual orientation?"


### PR DESCRIPTION
### What is the context of this PR?

Updated schemas as per definitions on card spreadsheet.

### How to review

Confirm changes are as per card. Ignore the change to business-name (this already exists and appears to not be showing due to a bug).

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/qa-content-changes-2/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/qa-content-changes-2/schemas/en/census_individual_gb_eng.json)

#### Wales

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/qa-content-changes-2/schemas/en/census_household_gb_wls.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/qa-content-changes-2/schemas/en/census_individual_gb_wls.json)

