### PR TITLE
Update NISRA School Age Rule

### DIFF
--- a/source/jsonnet/northern-ireland/lib/common_rules.libsonnet
+++ b/source/jsonnet/northern-ireland/lib/common_rules.libsonnet
@@ -63,7 +63,7 @@
     id: 'date-of-birth-answer',
     condition: 'greater than',
     date_comparison: {
-      value: '2020-07-01',
+      value: '2020-06-30',
       offset_by: {
         years: -4,
       },

--- a/source/jsonnet/northern-ireland/lib/common_rules.libsonnet
+++ b/source/jsonnet/northern-ireland/lib/common_rules.libsonnet
@@ -73,7 +73,7 @@
     id: 'date-of-birth-answer',
     condition: 'less than or equal to',
     date_comparison: {
-      value: '2020-07-01',
+      value: '2020-06-30',
       offset_by: {
         years: -5,
       },


### PR DESCRIPTION
### What is the context of this PR?

The NISRA `schoolYearUnder4` and `schoolYear5AndOver` rules have been updated so that it is based on `30/06/2020` rather than `01/07/20`

### How to review

Check that the new routing rule is correct as per the Trello card

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-nisra-school-age/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-nisra-school-age/schemas/en/census_individual_gb_nir.json)
