### PR TITLE
Update NISRA lookup URLs

### DIFF
--- a/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_country.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_country.jsonnet
@@ -20,7 +20,7 @@ local rules = import 'rules.libsonnet';
         label: 'Current name of country',
         description: 'Enter your own answer or select from suggestions',
         mandatory: false,
-        suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+        suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
         type: 'TextField',
         max_length: 100,
       },

--- a/source/jsonnet/northern-ireland/individual/blocks/employment/workplace_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/employment/workplace_country.jsonnet
@@ -10,6 +10,7 @@ local question(title) = {
       id: 'workplace-country-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
       mandatory: false,
       type: 'TextField',
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/ethnic_group_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/ethnic_group_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/ethnic-groups.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/ethnic-groups.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/no_religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/no_religion_other.jsonnet
@@ -19,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/religions.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/religions.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_main_language.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_main_language.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/languages.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/languages.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/national-identities.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/national-identities.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/national-identities.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/national-identities.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/passport-countries.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/passport-countries.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/passport-countries.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/passport-countries.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
@@ -19,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/religions.json',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/religions.json',
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_country_outside_uk.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_country_outside_uk.jsonnet
@@ -10,6 +10,7 @@ local question(title) = {
       id: 'term-time-country-outside-uk-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
       mandatory: false,
       type: 'TextField',
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/school/study_location_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/school/study_location_country.jsonnet
@@ -10,6 +10,7 @@ local question(title) = {
       id: 'study-location-country-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
+      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
       mandatory: false,
       type: 'TextField',
     },


### PR DESCRIPTION
### What is the context of this PR?

Adds NISRA lookups to the NI Household and Individual schemas (they were previously using Eng/Wls lookups).

### How to review

Check that the correct lookups have been added to the questions as per the trello card.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-nisra-lookups/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-nisra-lookups/schemas/en/census_individual_gb_nir.json)
