### PR TITLE
Make arrive in uk question optional

### DIFF
--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
@@ -11,7 +11,7 @@ local question(title) = {
   answers: [
     {
       id: 'arrive-in-uk-answer',
-      mandatory: true,
+      mandatory: false,
       type: 'MonthYearDate',
       minimum: {
         value: {


### PR DESCRIPTION
### What is the context of this PR?

Make arrive in uk question optional. Routing changes are not needed.

### How to review

Ensure arrive in uk question is now optional.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/remove-mandatory-from-arrive-in-uk/schemas/en/census_individual_gb_eng.json)