### PR TITLE
Extend schemas to resolve suggestions url language

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-tag=latest
+tag=add-suggestions-placeholder
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -155,6 +155,10 @@ function(region_code, census_month_year_date) {
       name: 'display_address',
       type: 'string',
     },
+    {
+      name: 'language_code',
+      type: 'string',
+    },
   ],
   hub: {
     enabled: true,

--- a/source/jsonnet/england-wales/census_individual.jsonnet
+++ b/source/jsonnet/england-wales/census_individual.jsonnet
@@ -121,6 +121,10 @@ function(region_code, census_month_year_date) {
       name: 'display_address',
       type: 'string',
     },
+    {
+      name: 'language_code',
+      type: 'string',
+    },
   ],
   sections: [
     {

--- a/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_country.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_country.jsonnet
@@ -21,7 +21,12 @@ local rules = import 'rules.libsonnet';
         label: 'Current name of country',
         description: 'Enter your own answer or select from suggestions',
         mandatory: false,
-        suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+        suggestions_url: {
+          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+          placeholders: [
+            placeholders.languageCode,
+          ],
+        },
         type: 'TextField',
         max_length: 100,
       },

--- a/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_country.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_country.jsonnet
@@ -22,7 +22,7 @@ local rules = import 'rules.libsonnet';
         description: 'Enter your own answer or select from suggestions',
         mandatory: false,
         suggestions_url: {
-          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/countries-of-birth.json',
           placeholders: [
             placeholders.languageCode,
           ],

--- a/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/countries-of-birth.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/countries-of-birth.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/countries-of-birth.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_asian_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_asian_other.jsonnet
@@ -16,7 +16,12 @@ local question(englandTitle, walesTitle, region_code) = (
         description: 'Enter your own answer or select from suggestions',
         max_length: 100,
         mandatory: false,
-        suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/ethnic-groups.json',
+        suggestions_url: {
+          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+          placeholders: [
+            placeholders.languageCode,
+          ],
+        },
         type: 'TextField',
       },
     ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_asian_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_asian_other.jsonnet
@@ -17,7 +17,7 @@ local question(englandTitle, walesTitle, region_code) = (
         max_length: 100,
         mandatory: false,
         suggestions_url: {
-          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/ethnic-groups.json',
           placeholders: [
             placeholders.languageCode,
           ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_african.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_african.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/ethnic-groups.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_african.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_african.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/ethnic-groups.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
@@ -16,7 +16,12 @@ local question(englandTitle, walesTitle, region_code) = (
         description: 'Enter your own answer or select from suggestions',
         max_length: 100,
         mandatory: false,
-        suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/ethnic-groups.json',
+        suggestions_url: {
+          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+          placeholders: [
+            placeholders.languageCode,
+          ],
+        },
         type: 'TextField',
       },
     ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
@@ -17,7 +17,7 @@ local question(englandTitle, walesTitle, region_code) = (
         max_length: 100,
         mandatory: false,
         suggestions_url: {
-          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+          text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/ethnic-groups.json',
           placeholders: [
             placeholders.languageCode,
           ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/ethnic-groups.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/ethnic-groups.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_white_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_white_other.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/ethnic-groups.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_white_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_white_other.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/ethnic-groups.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/ethnic-groups.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_main_language.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_main_language.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/languages.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/languages.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_main_language.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_main_language.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/languages.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/languages.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -20,7 +20,7 @@ local question(title, guidance) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/national-identities.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/national-identities.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -19,7 +19,12 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/national-identities.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/national-identities.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -20,7 +20,7 @@ local question(title, guidance) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/national-identities.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/national-identities.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -19,7 +19,12 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/national-identities.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/national-identities.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -19,7 +19,12 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/passport-countries.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/passport-countries.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -20,7 +20,7 @@ local question(title, guidance) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/passport-countries.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/passport-countries.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -19,7 +19,12 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/passport-countries.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/passport-countries.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -20,7 +20,7 @@ local question(title, guidance) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/passport-countries.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/passport-countries.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion_other.jsonnet
@@ -19,7 +19,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/religions.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/religions.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion_other.jsonnet
@@ -20,7 +20,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/religions.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/religions.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: true,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/countries-of-birth.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: true,
-      ssuggestions_url: {
+      suggestions_url: {
         text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
         placeholders: [
           placeholders.languageCode,

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: true,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+      ssuggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
       validation: {
         messages: {

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
       max_length: 100,
       mandatory: false,
       suggestions_url: {
-        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/gb/{language_code}/countries-of-birth.json',
         placeholders: [
           placeholders.languageCode,
         ],

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
@@ -12,7 +12,12 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v1.0.0/countries-of-birth.json',
+      suggestions_url: {
+        text: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/gb/{language_code}/countries-of-birth.json',
+        placeholders: [
+          placeholders.languageCode,
+        ],
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/lib/placeholders.libsonnet
+++ b/source/jsonnet/england-wales/lib/placeholders.libsonnet
@@ -175,6 +175,7 @@ local firstPersonNamePossessiveForList(listName) = {
     }],
   },
   languageCode: {
+    placeholder: 'language_code',
     value: {
       identifier: 'language_code',
       source: 'metadata',

--- a/source/jsonnet/england-wales/lib/placeholders.libsonnet
+++ b/source/jsonnet/england-wales/lib/placeholders.libsonnet
@@ -174,6 +174,12 @@ local firstPersonNamePossessiveForList(listName) = {
       },
     }],
   },
+  languageCode: {
+    value: {
+      identifier: 'language_code',
+      source: 'metadata',
+    },
+  },
   getListOrdinality: getListOrdinality,
   getListOrdinalityWithoutDeterminer: getListOrdinalityWithoutDeterminer,
   getListCardinality: getListCardinality,

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -143,10 +143,6 @@ function(region_code) {
       name: 'display_address',
       type: 'string',
     },
-    {
-      name: 'language_code',
-      type: 'string',
-    },
   ],
   hub: {
     enabled: true,

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -143,6 +143,10 @@ function(region_code) {
       name: 'display_address',
       type: 'string',
     },
+    {
+      name: 'language_code',
+      type: 'string',
+    },
   ],
   hub: {
     enabled: true,

--- a/source/jsonnet/northern-ireland/census_individual.jsonnet
+++ b/source/jsonnet/northern-ireland/census_individual.jsonnet
@@ -110,10 +110,6 @@ function(region_code) {
       name: 'display_address',
       type: 'string',
     },
-    {
-      name: 'language_code',
-      type: 'string',
-    },
   ],
   sections: [
     {

--- a/source/jsonnet/northern-ireland/census_individual.jsonnet
+++ b/source/jsonnet/northern-ireland/census_individual.jsonnet
@@ -110,6 +110,10 @@ function(region_code) {
       name: 'display_address',
       type: 'string',
     },
+    {
+      name: 'language_code',
+      type: 'string',
+    },
   ],
   sections: [
     {

--- a/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_country.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_country.jsonnet
@@ -1,6 +1,12 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'countries-of-birth.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
 
 {
   type: 'Question',
@@ -20,7 +26,7 @@ local rules = import 'rules.libsonnet';
         label: 'Current name of country',
         description: 'Enter your own answer or select from suggestions',
         mandatory: false,
-        suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
+        suggestions_url: suggestionsUrl,
         type: 'TextField',
         max_length: 100,
       },

--- a/source/jsonnet/northern-ireland/individual/blocks/employment/workplace_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/employment/workplace_country.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'countries-of-birth.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'workplace-country-question',
   title: title,
@@ -10,7 +17,7 @@ local question(title) = {
       id: 'workplace-country-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
+      suggestions_url: suggestionsUrl,
       mandatory: false,
       type: 'TextField',
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'countries-of-birth.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'address-one-year-ago-outside-uk-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/childhood_religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/childhood_religion_other.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'religions.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'childhood-religion-other-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/religions.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'countries-of-birth.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'country-of-birth-elsewhere-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/ethnic_group_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/ethnic_group_other.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'ethnic-groups.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'ethnic-group-other-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/ethnic-groups.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_main_language.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_main_language.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'languages.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'other-main-language-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/languages.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'national-identities.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'other-national-identities-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/national-identities.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'national-identities.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'other-national-identity-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/national-identities.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'passport-countries.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'passports-additional-other-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/passport-countries.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'passport-countries.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'passports-other-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/passport-countries.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'religions.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'religion-other-question',
   title: title,
@@ -12,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/religions.json',
+      suggestions_url: suggestionsUrl,
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_country_outside_uk.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_country_outside_uk.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'countries-of-birth.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'term-time-country-outside-uk-question',
   title: title,
@@ -10,7 +17,7 @@ local question(title) = {
       id: 'term-time-country-outside-uk-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
+      suggestions_url: suggestionsUrl,
       mandatory: false,
       type: 'TextField',
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/school/study_location_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/school/study_location_country.jsonnet
@@ -1,6 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
+local listName = 'countries-of-birth.json';
+
+local suggestionsUrl = {
+  text: '{suggestions_url}',
+  placeholders: [placeholders.suggestionsUrl(listName)],
+};
+
 local question(title) = {
   id: 'study-location-country-question',
   title: title,
@@ -10,7 +17,7 @@ local question(title) = {
       id: 'study-location-country-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
-      suggestions_url: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v2.0.0/ni/countries-of-birth.json',
+      suggestions_url: suggestionsUrl,
       mandatory: false,
       type: 'TextField',
     },

--- a/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
+++ b/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
@@ -85,7 +85,7 @@ local suggestionsUrl(listName) = {
   placeholder: 'suggestions_url',
   transforms: [
     {
-      transform: 'get_nisra_suggestions_url',
+      transform: 'format_suggestions_url',
       arguments: {
         url: {
           value: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/',

--- a/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
+++ b/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
@@ -88,7 +88,7 @@ local suggestionsUrl(listName) = {
       transform: 'format_suggestions_url',
       arguments: {
         url: {
-          value: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/',
+          value: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/ni/en/',
         },
         list_json: {
           value: listName,

--- a/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
+++ b/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
@@ -85,7 +85,7 @@ local suggestionsUrl(listName) = {
   placeholder: 'suggestions_url',
   transforms: [
     {
-      transform: 'format_suggestions_url',
+      transform: 'format_nisra_suggestions_url',
       arguments: {
         url: {
           value: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v4.0.0/ni/en/',

--- a/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
+++ b/source/jsonnet/northern-ireland/lib/placeholders.libsonnet
@@ -81,6 +81,22 @@ local firstPersonNamePossessiveForList(listName) = {
     },
   ],
 };
+local suggestionsUrl(listName) = {
+  placeholder: 'suggestions_url',
+  transforms: [
+    {
+      transform: 'get_nisra_suggestions_url',
+      arguments: {
+        url: {
+          value: 'https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/',
+        },
+        list_json: {
+          value: listName,
+        },
+      },
+    },
+  ],
+};
 {
   personName: {
     placeholder: 'person_name',
@@ -198,6 +214,7 @@ local firstPersonNamePossessiveForList(listName) = {
       },
     ],
   },
+  suggestionsUrl: suggestionsUrl,
   getListOrdinality: getListOrdinality,
   getListCardinality: getListCardinality,
   firstPersonNameForList: firstPersonNameForList,


### PR DESCRIPTION
### What is the context of this PR?

This adds new placeholder to suggestions url and resolves it based on survey language. Different approach was used for ENG-WLS schemas and NI schemas (which required adding new transform to runner). It's described on [this Trello card](https://trello.com/c/WSPjAC5y).

### How to review

Describe the steps required to test the changes (include screenshots if appropriate).

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/en/census_individual_gb_eng.json)

#### Wales - Welsh

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/cy/census_household_gb_wls.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/cy/census_individual_gb_wls.json)

#### Northern Ireland - English

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/en/census_individual_gb_nir.json)

#### Northern Ireland - Gaelic

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/ga/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-suggestions-url-placeholder/schemas/ga/census_individual_gb_nir.json)