### PR TITLE
Implement IR feature on HH schema

### DIFF
--- a/source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/source/jsonnet/england-wales/ccs_household.jsonnet
@@ -98,6 +98,10 @@ function(region_code, census_month_year_date) {
     enabled: true,
     required_completed_sections: ['who-lives-here-and-visitors'],
   },
+  individual_response: {
+    for_list: 'household',
+    individual_section_id: 'individual-section',
+  },
   submission: {
     button: 'Submit census',
     title: 'Submit census',

--- a/source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/source/jsonnet/england-wales/ccs_household.jsonnet
@@ -98,10 +98,6 @@ function(region_code, census_month_year_date) {
     enabled: true,
     required_completed_sections: ['who-lives-here-and-visitors'],
   },
-  individual_response: {
-    for_list: 'household',
-    individual_section_id: 'individual-section',
-  },
   submission: {
     button: 'Submit census',
     title: 'Submit census',

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -160,6 +160,10 @@ function(region_code, census_month_year_date) {
     enabled: true,
     required_completed_sections: ['people-who-live-here-and-overnight-visitors', 'relationships-section'],
   },
+  individual_response: {
+    for_list: 'household',
+    individual_section_id: 'individual-section',
+  },
   submission: {
     button: 'Submit census',
     guidance: 'By submitting this census you are confirming that, to the best of your knowledge and belief, the details provided are correct.',

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -148,6 +148,10 @@ function(region_code) {
     enabled: true,
     required_completed_sections: ['who-lives-here-section', 'relationships-section'],
   },
+  individual_response: {
+    for_list: 'household',
+    individual_section_id: 'individual-section',
+  },
   submission: {
     button: 'Submit census',
     guidance: 'By submitting this census return you are confirming that, to the best of your knowledge and belief, the details provided are correct.',


### PR DESCRIPTION
### What is the context of this PR?

Add IR to all household schemas

### How to review

Check the IR option is available on each schema

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/implement-ir-hh/schemas/en/census_household_gb_eng.json)

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/implement-ir-hh/schemas/en/ccs_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/implement-ir-hh/schemas/en/census_household_gb_nir.json)
