### PR TITLE
Add repeat identifier to schemas

### DIFF
--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -328,7 +328,7 @@ function(region_code, census_month_year_date) {
             },
           ],
         },
-        "page_title": "Person {list_item_position}",
+        page_title: 'Person {list_item_position}',
       },
       groups: [
         {
@@ -471,7 +471,7 @@ function(region_code, census_month_year_date) {
             },
           ],
         },
-        "page_title": "Visitor {list_item_position}",
+        page_title: 'Visitor {list_item_position}',
       },
       groups: [
         {

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -328,6 +328,7 @@ function(region_code, census_month_year_date) {
             },
           ],
         },
+        "page_title": "Person {list_item_position}",
       },
       groups: [
         {
@@ -470,6 +471,7 @@ function(region_code, census_month_year_date) {
             },
           ],
         },
+        "page_title": "Visitor {list_item_position}",
       },
       groups: [
         {

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -316,7 +316,7 @@ function(region_code) {
             },
           ],
         },
-        "page_title": "Person {list_item_position}",
+        page_title: 'Person {list_item_position}',
       },
       groups: [
         {
@@ -454,7 +454,7 @@ function(region_code) {
             },
           ],
         },
-        "page_title": "Visitor {list_item_position}"
+        page_title: 'Visitor {list_item_position}',
       },
       groups: [
         {

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -316,6 +316,7 @@ function(region_code) {
             },
           ],
         },
+        "page_title": "Person {list_item_position}",
       },
       groups: [
         {
@@ -453,6 +454,7 @@ function(region_code) {
             },
           ],
         },
+        "page_title": "Visitor {list_item_position}"
       },
       groups: [
         {

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-18 09:43+0100\n"
+"POT-Creation-Date: 2020-09-22 11:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -464,6 +464,11 @@ msgid "Travel to study location"
 msgstr ""
 
 #. Page title
+#. Section page title suffix (repeating section)
+msgid "Person {list_item_position}"
+msgstr ""
+
+#. Page title
 msgid "Individual summary"
 msgstr ""
 
@@ -481,6 +486,11 @@ msgstr ""
 
 #. Page title
 msgid "Usual address country"
+msgstr ""
+
+#. Page title
+#. Section page title suffix (repeating section)
+msgid "Visitor {list_item_position}"
 msgstr ""
 
 #. Page title

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-18 09:43+0100\n"
+"POT-Creation-Date: 2020-09-22 11:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -519,6 +519,11 @@ msgid "Mainly work outside the UK"
 msgstr ""
 
 #. Page title
+#. Section page title suffix (repeating section)
+msgid "Person {list_item_position}"
+msgstr ""
+
+#. Page title
 msgid "Individual summary"
 msgstr ""
 
@@ -536,6 +541,11 @@ msgstr ""
 
 #. Page title
 msgid "Usual address country"
+msgstr ""
+
+#. Page title
+#. Section page title suffix (repeating section)
+msgid "Visitor {list_item_position}"
 msgstr ""
 
 #. Page title


### PR DESCRIPTION
### What is the context of this PR?
Page titles have now been added to repeating sections

### How to review

Goto the repeat section and make sure the page title is correctly formatted, it should be ```<block page_title><section page_title> - Census 2021 ```

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-repeat-identifier-to-schemas/schemas/en/census_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-repeat-identifier-to-schemas/schemas/en/census_household_gb_nir.json)
