### PR TITLE
Fix HI page titles (ENG/WLS/NI) and remove extra definitions

### DIFF
--- a/source/jsonnet/england-wales/census_communal_establishment.jsonnet
+++ b/source/jsonnet/england-wales/census_communal_establishment.jsonnet
@@ -41,7 +41,7 @@ function(region_code, census_month_year_date) {
       groups: [
         {
           id: 'establishment-details-group',
-          title: 'Personal Details',
+          title: 'Personal details',
           blocks: [
             establishment_details,
             medical_establishment,

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -333,7 +333,7 @@ function(region_code, census_month_year_date) {
       groups: [
         {
           id: 'personal-details-group',
-          title: 'Personal Details',
+          title: 'Personal details',
           blocks: [
             individual_introduction,
             proxy,
@@ -358,7 +358,7 @@ function(region_code, census_month_year_date) {
         },
         {
           id: 'identity-and-health-group',
-          title: 'Identity and Health',
+          title: 'Identity and health',
           blocks: [
             country_of_birth(region_code),
             country_of_birth_elsewhere,

--- a/source/jsonnet/england-wales/census_individual.jsonnet
+++ b/source/jsonnet/england-wales/census_individual.jsonnet
@@ -129,7 +129,7 @@ function(region_code, census_month_year_date) {
       groups: [
         {
           id: 'personal-details-group',
-          title: 'Personal Details',
+          title: 'Personal details',
           blocks: [
             accommodation_type,
             proxy,
@@ -156,7 +156,7 @@ function(region_code, census_month_year_date) {
         },
         {
           id: 'identity-and-health-group',
-          title: 'Identity and Health',
+          title: 'Identity and health',
           blocks: [
             country_of_birth(region_code),
             country_of_birth_elsewhere,

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/establishment_position.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/establishment_position.jsonnet
@@ -4,16 +4,6 @@ local rules = import 'rules.libsonnet';
 local question(title) = {
   id: 'establishment-position-question',
   title: title,
-  definitions: [
-    {
-      title: 'What we mean by “establishment”',
-      contents: [
-        {
-          description: 'A communal establishment is an establishment providing managed residential accommodation. ”Managed” in this context means full-time or part-time supervision of the accommodation. Examples of communal establishments include student halls of residence, boarding schools, armed forces bases, hospitals, care homes and prisons.',
-        },
-      ],
-    },
-  ],
   type: 'General',
   answers: [
     {

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -321,7 +321,7 @@ function(region_code) {
       groups: [
         {
           id: 'personal-details-group',
-          title: 'Personal Details',
+          title: 'Personal details',
           blocks: [
             individual_introduction,
             proxy,
@@ -338,7 +338,7 @@ function(region_code) {
         },
         {
           id: 'identity-and-health-group',
-          title: 'Identity and Health',
+          title: 'Identity and health',
           blocks: [
             country_of_birth,
             country_of_birth_elsewhere,

--- a/source/jsonnet/northern-ireland/census_individual.jsonnet
+++ b/source/jsonnet/northern-ireland/census_individual.jsonnet
@@ -118,7 +118,7 @@ function(region_code) {
       groups: [
         {
           id: 'personal-details-group',
-          title: 'Personal Details',
+          title: 'Personal details',
           blocks: [
             accommodation_type,
             proxy,
@@ -137,7 +137,7 @@ function(region_code) {
         },
         {
           id: 'identity-and-health-group',
-          title: 'Identity and Health',
+          title: 'Identity and health',
           blocks: [
             country_of_birth,
             country_of_birth_elsewhere,

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/establishment_position.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/establishment_position.jsonnet
@@ -4,16 +4,6 @@ local rules = import 'rules.libsonnet';
 local question(title) = {
   id: 'establishment-position-question',
   title: title,
-  definitions: [
-    {
-      title: 'What is an establishment?',
-      contents: [
-        {
-          description: 'A communal establishment is an establishment providing managed residential accommodation. “Managed” in this context means full-time or part-time supervision of the accommodation. Examples of communal establishments include student halls of residence, boarding schools, armed forces bases, hospitals, care homes and prisons',
-        },
-      ],
-    },
-  ],
   type: 'General',
   answers: [
     {

--- a/translations/census_communal_establishment_gb_wls.pot
+++ b/translations/census_communal_establishment_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-22 08:18+0100\n"
+"POT-Creation-Date: 2020-09-24 08:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -75,7 +75,7 @@ msgid "Number of visitors staying in this establishment"
 msgstr ""
 
 #. Group title
-msgid "Personal Details"
+msgid "Personal details"
 msgstr ""
 
 #. Question text

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-22 11:29+0100\n"
+"POT-Creation-Date: 2020-09-24 08:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -548,11 +548,11 @@ msgid "Who lives here"
 msgstr ""
 
 #. Group title
-msgid "Personal Details"
+msgid "Personal details"
 msgstr ""
 
 #. Group title
-msgid "Identity and Health"
+msgid "Identity and health"
 msgstr ""
 
 #. Group title

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-22 11:29+0100\n"
+"POT-Creation-Date: 2020-09-24 08:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -603,11 +603,11 @@ msgid "Who lives here"
 msgstr ""
 
 #. Group title
-msgid "Personal Details"
+msgid "Personal details"
 msgstr ""
 
 #. Group title
-msgid "Identity and Health"
+msgid "Identity and health"
 msgstr ""
 
 #. Group title

--- a/translations/census_individual_gb_nir.pot
+++ b/translations/census_individual_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-17 12:27+0100\n"
+"POT-Creation-Date: 2020-09-24 08:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -331,11 +331,11 @@ msgid "Travel to study location"
 msgstr ""
 
 #. Group title
-msgid "Personal Details"
+msgid "Personal details"
 msgstr ""
 
 #. Group title
-msgid "Identity and Health"
+msgid "Identity and health"
 msgstr ""
 
 #. Group title
@@ -1475,16 +1475,6 @@ msgid "What we mean by “communal establishment”"
 msgstr ""
 
 #. Question definition link
-msgctxt "What is your position in this establishment?"
-msgid "What is an establishment?"
-msgstr ""
-
-#. Question definition link
-msgctxt "What is <em>{person_name_possessive}</em> position in this establishment?"
-msgid "What is an establishment?"
-msgstr ""
-
-#. Question definition link
 msgctxt "What passports do you hold?"
 msgid "What passports and travel documents to include"
 msgstr ""
@@ -1510,26 +1500,6 @@ msgid ""
 "A communal establishment is an establishment providing managed "
 "residential accommodation. “Managed” here means full-time or part-time "
 "supervision of the accommodation."
-msgstr ""
-
-#. Question definition description
-msgctxt "What is your position in this establishment?"
-msgid ""
-"A communal establishment is an establishment providing managed "
-"residential accommodation. “Managed” in this context means full-time or "
-"part-time supervision of the accommodation. Examples of communal "
-"establishments include student halls of residence, boarding schools, "
-"armed forces bases, hospitals, care homes and prisons"
-msgstr ""
-
-#. Question definition description
-msgctxt "What is <em>{person_name_possessive}</em> position in this establishment?"
-msgid ""
-"A communal establishment is an establishment providing managed "
-"residential accommodation. “Managed” in this context means full-time or "
-"part-time supervision of the accommodation. Examples of communal "
-"establishments include student halls of residence, boarding schools, "
-"armed forces bases, hospitals, care homes and prisons"
 msgstr ""
 
 #. Question definition description

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-17 12:12+0100\n"
+"POT-Creation-Date: 2020-09-24 08:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -385,11 +385,11 @@ msgid "Mainly work outside the UK"
 msgstr ""
 
 #. Group title
-msgid "Personal Details"
+msgid "Personal details"
 msgstr ""
 
 #. Group title
-msgid "Identity and Health"
+msgid "Identity and health"
 msgstr ""
 
 #. Group title
@@ -1635,16 +1635,6 @@ msgid "What we mean by “communal establishment”"
 msgstr ""
 
 #. Question definition link
-msgctxt "What is your position in this establishment?"
-msgid "What we mean by “establishment”"
-msgstr ""
-
-#. Question definition link
-msgctxt "What is <em>{person_name_possessive}</em> position in this establishment?"
-msgid "What we mean by “establishment”"
-msgstr ""
-
-#. Question definition link
 msgctxt "Do you stay at another address for more than 30 days a year?"
 msgid "What we mean by “another address”"
 msgstr ""
@@ -1743,26 +1733,6 @@ msgctxt "What type of accommodation is <em>{household_address}</em>?"
 msgid ""
 "This is a place providing managed residential accommodation. “Managed” "
 "here means full-time or part-time supervision of the accommodation."
-msgstr ""
-
-#. Question definition description
-msgctxt "What is your position in this establishment?"
-msgid ""
-"A communal establishment is an establishment providing managed "
-"residential accommodation. ”Managed” in this context means full-time or "
-"part-time supervision of the accommodation. Examples of communal "
-"establishments include student halls of residence, boarding schools, "
-"armed forces bases, hospitals, care homes and prisons."
-msgstr ""
-
-#. Question definition description
-msgctxt "What is <em>{person_name_possessive}</em> position in this establishment?"
-msgid ""
-"A communal establishment is an establishment providing managed "
-"residential accommodation. ”Managed” in this context means full-time or "
-"part-time supervision of the accommodation. Examples of communal "
-"establishments include student halls of residence, boarding schools, "
-"armed forces bases, hospitals, care homes and prisons."
 msgstr ""
 
 #. Question definition description


### PR DESCRIPTION
### What is the context of this PR?

This adds some page titles fixes and removes extra twisty from establishment-position. Change is described on [this Trello card](https://trello.com/c/0naqPfrU).

### How to review

Check page titles on _Personal details_ and _Identity and health_ answers summary pages. Check if twisty has been removed on establishment-position question.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/changes-individual-survey-content/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/changes-individual-survey-content/schemas/en/census_individual_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/changes-individual-survey-content/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/changes-individual-survey-content/schemas/en/census_individual_gb_nir.json)
