### PR TITLE
NISRA: Remove individual link from hub

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-tag=add-flag-for-ir-on-hub
+tag=latest
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-tag=latest
+tag=add-flag-for-ir-on-hub
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -149,6 +149,7 @@ function(region_code) {
     required_completed_sections: ['people-who-live-here-and-overnight-visitors', 'relationships-section'],
   },
   individual_response: {
+    show_on_hub: false,
     for_list: 'household',
     individual_section_id: 'individual-section',
   },


### PR DESCRIPTION
### What is the context of this PR?

The IR content on the hub should be configurable and the default set to on; this should be disabled for the NI HH schema.

### How to review

Use the `add-flag-for-ir` branch from runner. Check that the NI HH schema no longer shows the IR link on the hub, confirm for Eng/Wales it remains oh the hub.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

