### PR TITLE
Add custom summary content for CE schemas

### DIFF
--- a/source/jsonnet/england-wales/census_communal_establishment.jsonnet
+++ b/source/jsonnet/england-wales/census_communal_establishment.jsonnet
@@ -34,6 +34,12 @@ function(region_code, census_month_year_date) {
       type: 'string',
     },
   ],
+  submission: {
+    button: 'Submit census',
+    guidance: 'By submitting this census you are confirming that, to the best of your knowledge and belief, the details provided are correct.',
+    title: 'Submit census',
+    warning: 'You must submit this census to complete it',
+  },
   sections: [
     {
       id: 'communal-establishment',
@@ -41,7 +47,6 @@ function(region_code, census_month_year_date) {
       groups: [
         {
           id: 'establishment-details-group',
-          title: 'Personal details',
           blocks: [
             establishment_details,
             medical_establishment,

--- a/translations/census_communal_establishment_gb_wls.pot
+++ b/translations/census_communal_establishment_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-25 15:06+0100\n"
+"POT-Creation-Date: 2020-09-30 08:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,6 +23,21 @@ msgstr ""
 
 #. Questionnaire legal basis
 msgid "Voluntary"
+msgstr ""
+
+#. Submission button
+#. Submission title
+msgid "Submit census"
+msgstr ""
+
+#. Submission guidance
+msgid ""
+"By submitting this census you are confirming that, to the best of your "
+"knowledge and belief, the details provided are correct."
+msgstr ""
+
+#. Submission warning
+msgid "You must submit this census to complete it"
 msgstr ""
 
 #. Section title
@@ -72,10 +87,6 @@ msgstr ""
 
 #. Page title
 msgid "Number of visitors staying in this establishment"
-msgstr ""
-
-#. Group title
-msgid "Personal details"
 msgstr ""
 
 #. Question text


### PR DESCRIPTION
### What is the context of this PR?

Adds custom final summary content to the CE schemas (ENG/WLS). Minor change was required in runner's partials/summary templates to make this work. [Link to runner change](https://github.com/ONSdigital/eq-questionnaire-runner/pull/321).

### How to review

Check the custom content is correct as per the [Trello card](https://trello.com/c/7LiItQka).

Use this [runner branch](https://github.com/ONSdigital/eq-questionnaire-runner/pull/321) to test the change.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)
