### PR TITLE
Add email confirmation to schemas (Eng/Wls/NI)

### DIFF
--- a/source/jsonnet/england-wales/census_communal_establishment.jsonnet
+++ b/source/jsonnet/england-wales/census_communal_establishment.jsonnet
@@ -39,6 +39,7 @@ function(region_code, census_month_year_date) {
     guidance: 'By submitting this census you are confirming that, to the best of your knowledge and belief, the details provided are correct.',
     title: 'Submit census',
     warning: 'You must submit this census to complete it',
+    confirmation_email: true,
   },
   sections: [
     {

--- a/source/jsonnet/england-wales/census_household.jsonnet
+++ b/source/jsonnet/england-wales/census_household.jsonnet
@@ -169,6 +169,7 @@ function(region_code, census_month_year_date) {
     guidance: 'By submitting this census you are confirming that, to the best of your knowledge and belief, the details provided are correct.',
     title: 'Submit census',
     warning: 'You must submit this census to complete it',
+    confirmation_email: true,
   },
   sections: [
     {

--- a/source/jsonnet/england-wales/census_individual.jsonnet
+++ b/source/jsonnet/england-wales/census_individual.jsonnet
@@ -127,6 +127,7 @@ function(region_code, census_month_year_date) {
     guidance: 'By submitting this census you are confirming that, to the best of your knowledge and belief, the details provided are correct.',
     title: 'Submit census',
     warning: 'You must submit this census to complete it',
+    confirmation_email: true,
   },
   sections: [
     {

--- a/source/jsonnet/northern-ireland/census_household.jsonnet
+++ b/source/jsonnet/northern-ireland/census_household.jsonnet
@@ -158,6 +158,7 @@ function(region_code) {
     guidance: 'By submitting this census return you are confirming that, to the best of your knowledge and belief, the details provided are correct.',
     title: 'Submit census',
     warning: 'You must submit this census to complete it',
+    confirmation_email: true,
   },
   sections: [
     {

--- a/source/jsonnet/northern-ireland/census_individual.jsonnet
+++ b/source/jsonnet/northern-ireland/census_individual.jsonnet
@@ -116,6 +116,7 @@ function(region_code) {
     guidance: 'By submitting this census return you are confirming that, to the best of your knowledge and belief, the details provided are correct.',
     title: 'Submit census',
     warning: 'You must submit this census to complete it',
+    confirmation_email: true,
   },
   sections: [
     {


### PR DESCRIPTION
### What is the context of this PR?

Adds the option to send a confirmation email to the Individual, Household and Communal Establishment schemas (Eng/Wls/NI).

### How to review

Check that there is an option to send a confirmation email on the `Thank You` page

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-confirmation-email-to-schemas/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-confirmation-email-to-schemas/schemas/en/census_individual_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-confirmation-email-to-schemas/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-confirmation-email-to-schemas/schemas/en/census_individual_gb_nir.json)
