### PR TITLE
Update custom validation error messages HH/HI(Eng/Wls/NI)

### DIFF
--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
@@ -39,7 +39,7 @@ local question(isProxy) = {
       },
       validation: {
         messages: {
-          MANDATORY_DATE: 'Enter a valid date of arrival',
+          INVALID_DATE: 'Enter a valid date of arrival',
           SINGLE_DATE_PERIOD_TOO_EARLY: errorMessage(isProxy),
           SINGLE_DATE_PERIOD_TOO_LATE: 'Enter a date of arrival that is in the past',
         },

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
@@ -13,7 +13,7 @@ local questionTitle(isProxy) = (
 
 local errorMessage(isProxy) = (
   if isProxy then 'Enter a date of arrival that is after their date of birth'
-  else 'Enter a date of arrival that is after their date of birth'
+  else 'Enter a date of arrival that is after your date of birth'
 );
 
 local question(isProxy) = {

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
@@ -1,9 +1,24 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title, message) = {
+local questionTitle(isProxy) = (
+  if isProxy then {
+    text: 'When did <em>{person_name}</em> most recently arrive to live in the United Kingdom?',
+    placeholders: [
+      placeholders.personName(),
+    ],
+  }
+  else 'When did you most recently arrive to live in the United Kingdom?'
+);
+
+local errorMessage(isProxy) = (
+  if isProxy then 'Enter a date of arrival that is after their date of birth'
+  else 'Enter a date of arrival that is after their date of birth'
+);
+
+local question(isProxy) = {
   id: 'arrive-in-uk-question',
-  title: title,
+  title: questionTitle(isProxy),
   type: 'General',
   description: [
     'Do not count short visits away from the UK',
@@ -25,7 +40,7 @@ local question(title, message) = {
       validation: {
         messages: {
           MANDATORY_DATE: 'Enter a valid date of arrival',
-          SINGLE_DATE_PERIOD_TOO_EARLY: message,
+          SINGLE_DATE_PERIOD_TOO_EARLY: errorMessage(isProxy),
           SINGLE_DATE_PERIOD_TOO_LATE: 'Enter a date of arrival that is in the past',
         },
       },
@@ -33,27 +48,17 @@ local question(title, message) = {
   ],
 };
 
-local nonProxyTitle = 'When did you most recently arrive to live in the United Kingdom?';
-local proxyTitle = {
-  text: 'When did <em>{person_name}</em> most recently arrive to live in the United Kingdom?',
-  placeholders: [
-    placeholders.personName(),
-  ],
-};
-local nonProxyErrorMessage = 'Enter a date of arrival that is after your date of birth';
-local proxyErrorMessage = 'Enter a date of arrival that is after their date of birth';
-
 function(region_code, census_month_year_date) {
   type: 'Question',
   id: 'arrive-in-uk',
   page_title: 'Arrived to live in the UK',
   question_variants: [
     {
-      question: question(nonProxyTitle, nonProxyErrorMessage),
+      question: question(isProxy=false),
       when: [rules.isNotProxy],
     },
     {
-      question: question(proxyTitle, proxyErrorMessage),
+      question: question(isProxy=true),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_uk.jsonnet
@@ -1,7 +1,7 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local question(title) = {
+local question(title, message) = {
   id: 'arrive-in-uk-question',
   title: title,
   type: 'General',
@@ -24,7 +24,9 @@ local question(title) = {
       },
       validation: {
         messages: {
-          MANDATORY_DATE: 'Enter a date of arrival',
+          MANDATORY_DATE: 'Enter a valid date of arrival',
+          SINGLE_DATE_PERIOD_TOO_EARLY: message,
+          SINGLE_DATE_PERIOD_TOO_LATE: 'Enter a date of arrival that is in the past',
         },
       },
     },
@@ -38,6 +40,8 @@ local proxyTitle = {
     placeholders.personName(),
   ],
 };
+local nonProxyErrorMessage = 'Enter a date of arrival that is after your date of birth';
+local proxyErrorMessage = 'Enter a date of arrival that is after their date of birth';
 
 function(region_code, census_month_year_date) {
   type: 'Question',
@@ -45,11 +49,11 @@ function(region_code, census_month_year_date) {
   page_title: 'Arrived to live in the UK',
   question_variants: [
     {
-      question: question(nonProxyTitle),
+      question: question(nonProxyTitle, nonProxyErrorMessage),
       when: [rules.isNotProxy],
     },
     {
-      question: question(proxyTitle),
+      question: question(proxyTitle, proxyErrorMessage),
       when: [rules.isProxy],
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/date_of_birth.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/date_of_birth.jsonnet
@@ -25,6 +25,9 @@ local question(title) = {
       validation: {
         messages: {
           MANDATORY_DATE: 'Enter a date of birth',
+          INVALID_DATE: 'Enter a valid date of birth',
+          SINGLE_DATE_PERIOD_TOO_EARLY: 'Enter a date of birth after %(min)s',
+          SINGLE_DATE_PERIOD_TOO_LATE: 'Enter a date of birth before %(max)s',
         },
       },
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/arrive_in_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/arrive_in_country.jsonnet
@@ -21,7 +21,6 @@ local question(title) = {
       },
       validation: {
         messages: {
-          MANDATORY_DATE: 'Enter a year of arrival',
           SINGLE_DATE_PERIOD_TOO_EARLY: 'Enter a year of arrival after %(min)s',
           SINGLE_DATE_PERIOD_TOO_LATE: 'Enter a year of arrival before %(max)s',
         },

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/arrive_in_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/arrive_in_country.jsonnet
@@ -22,6 +22,8 @@ local question(title) = {
       validation: {
         messages: {
           MANDATORY_DATE: 'Enter a year of arrival',
+          SINGLE_DATE_PERIOD_TOO_EARLY: 'Enter a year of arrival after %(min)s',
+          SINGLE_DATE_PERIOD_TOO_LATE: 'Enter a year of arrival before %(max)s',
         },
       },
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/age_last_birthday.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/age_last_birthday.jsonnet
@@ -26,6 +26,11 @@ local rules = import 'rules.libsonnet';
         maximum: {
           value: 115,
         },
+        validation: {
+          messages: {
+            NUMBER_TOO_LARGE: 'Enter an age less than or equal to %(max)s years',
+          },
+        },
       },
       {
         id: 'age-estimate-answer',

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/date_of_birth.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/date_of_birth.jsonnet
@@ -16,6 +16,9 @@ local question(title, mandatory) = {
       validation: {
         messages: {
           MANDATORY_DATE: 'Enter a date of birth',
+          INVALID_DATE: 'Enter a valid date of birth',
+          SINGLE_DATE_PERIOD_TOO_EARLY: 'Enter a date of birth after %(min)s',
+          SINGLE_DATE_PERIOD_TOO_LATE: 'Enter a date of birth before %(max)s',
         },
       },
       minimum: {

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-14 12:03+0100\n"
+"POT-Creation-Date: 2020-10-15 09:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2600,11 +2600,6 @@ msgid "Enter an age less than or equal to %(max)s years"
 msgstr ""
 
 #. Answer error message
-msgctxt "What year did you come to live in Northern Ireland?"
-msgid "Enter a year of arrival"
-msgstr ""
-
-#. Answer error message
 #, python-format
 msgctxt "What year did you come to live in Northern Ireland?"
 msgid "Enter a year of arrival after %(min)s"
@@ -2614,11 +2609,6 @@ msgstr ""
 #, python-format
 msgctxt "What year did you come to live in Northern Ireland?"
 msgid "Enter a year of arrival before %(max)s"
-msgstr ""
-
-#. Answer error message
-msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
-msgid "Enter a year of arrival"
 msgstr ""
 
 #. Answer error message

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-02 12:11+0100\n"
+"POT-Creation-Date: 2020-10-14 12:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2551,7 +2551,29 @@ msgstr ""
 
 #. Answer error message
 msgctxt "What is your date of birth?"
+msgid "Enter a valid date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is your date of birth?"
 msgid "Enter a date of birth"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth before %(max)s"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a valid date of birth"
 msgstr ""
 
 #. Answer error message
@@ -2560,13 +2582,55 @@ msgid "Enter a date of birth"
 msgstr ""
 
 #. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth before %(max)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What was <em>{person_name_possessive}</em> age on their last birthday?"
+msgid "Enter an age less than or equal to %(max)s years"
+msgstr ""
+
+#. Answer error message
 msgctxt "What year did you come to live in Northern Ireland?"
 msgid "Enter a year of arrival"
 msgstr ""
 
 #. Answer error message
+#, python-format
+msgctxt "What year did you come to live in Northern Ireland?"
+msgid "Enter a year of arrival after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What year did you come to live in Northern Ireland?"
+msgid "Enter a year of arrival before %(max)s"
+msgstr ""
+
+#. Answer error message
 msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
 msgid "Enter a year of arrival"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
+msgid "Enter a year of arrival after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
+msgid "Enter a year of arrival before %(max)s"
 msgstr ""
 
 #. Answer

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-25 15:06+0100\n"
+"POT-Creation-Date: 2020-10-14 12:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3122,12 +3122,46 @@ msgstr ""
 
 #. Answer error message
 msgctxt "What is your date of birth?"
+msgid "Enter a valid date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is your date of birth?"
 msgid "Enter a date of birth"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth before %(max)s"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a valid date of birth"
 msgstr ""
 
 #. Answer error message
 msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
 msgid "Enter a date of birth"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth before %(max)s"
 msgstr ""
 
 #. Answer error message
@@ -3144,14 +3178,38 @@ msgstr ""
 
 #. Answer error message
 msgctxt "When did you most recently arrive to live in the United Kingdom?"
-msgid "Enter a date of arrival"
+msgid "Enter a valid date of arrival"
+msgstr ""
+
+#. Answer error message
+msgctxt "When did you most recently arrive to live in the United Kingdom?"
+msgid "Enter a date of arrival that is after your date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt "When did you most recently arrive to live in the United Kingdom?"
+msgid "Enter a date of arrival that is in the past"
 msgstr ""
 
 #. Answer error message
 msgctxt ""
 "When did <em>{person_name}</em> most recently arrive to live in the "
 "United Kingdom?"
-msgid "Enter a date of arrival"
+msgid "Enter a valid date of arrival"
+msgstr ""
+
+#. Answer error message
+msgctxt ""
+"When did <em>{person_name}</em> most recently arrive to live in the "
+"United Kingdom?"
+msgid "Enter a date of arrival that is after their date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt ""
+"When did <em>{person_name}</em> most recently arrive to live in the "
+"United Kingdom?"
+msgid "Enter a date of arrival that is in the past"
 msgstr ""
 
 #. Answer

--- a/translations/census_individual_gb_nir.pot
+++ b/translations/census_individual_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-02 12:11+0100\n"
+"POT-Creation-Date: 2020-10-14 12:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1704,7 +1704,29 @@ msgstr ""
 
 #. Answer error message
 msgctxt "What is your date of birth?"
+msgid "Enter a valid date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is your date of birth?"
 msgid "Enter a date of birth"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth before %(max)s"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a valid date of birth"
 msgstr ""
 
 #. Answer error message
@@ -1713,13 +1735,55 @@ msgid "Enter a date of birth"
 msgstr ""
 
 #. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth before %(max)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What was <em>{person_name_possessive}</em> age on their last birthday?"
+msgid "Enter an age less than or equal to %(max)s years"
+msgstr ""
+
+#. Answer error message
 msgctxt "What year did you come to live in Northern Ireland?"
 msgid "Enter a year of arrival"
 msgstr ""
 
 #. Answer error message
+#, python-format
+msgctxt "What year did you come to live in Northern Ireland?"
+msgid "Enter a year of arrival after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What year did you come to live in Northern Ireland?"
+msgid "Enter a year of arrival before %(max)s"
+msgstr ""
+
+#. Answer error message
 msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
 msgid "Enter a year of arrival"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
+msgid "Enter a year of arrival after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
+msgid "Enter a year of arrival before %(max)s"
 msgstr ""
 
 #. Answer

--- a/translations/census_individual_gb_nir.pot
+++ b/translations/census_individual_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-14 12:03+0100\n"
+"POT-Creation-Date: 2020-10-15 09:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1753,11 +1753,6 @@ msgid "Enter an age less than or equal to %(max)s years"
 msgstr ""
 
 #. Answer error message
-msgctxt "What year did you come to live in Northern Ireland?"
-msgid "Enter a year of arrival"
-msgstr ""
-
-#. Answer error message
 #, python-format
 msgctxt "What year did you come to live in Northern Ireland?"
 msgid "Enter a year of arrival after %(min)s"
@@ -1767,11 +1762,6 @@ msgstr ""
 #, python-format
 msgctxt "What year did you come to live in Northern Ireland?"
 msgid "Enter a year of arrival before %(max)s"
-msgstr ""
-
-#. Answer error message
-msgctxt "What year did <em>{person_name}</em> come to live in Northern Ireland?"
-msgid "Enter a year of arrival"
 msgstr ""
 
 #. Answer error message

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-29 10:39+0100\n"
+"POT-Creation-Date: 2020-10-14 12:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2270,12 +2270,46 @@ msgstr ""
 
 #. Answer error message
 msgctxt "What is your date of birth?"
+msgid "Enter a valid date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is your date of birth?"
 msgid "Enter a date of birth"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is your date of birth?"
+msgid "Enter a date of birth before %(max)s"
+msgstr ""
+
+#. Answer error message
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a valid date of birth"
 msgstr ""
 
 #. Answer error message
 msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
 msgid "Enter a date of birth"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth after %(min)s"
+msgstr ""
+
+#. Answer error message
+#, python-format
+msgctxt "What is <em>{person_name_possessive}</em> date of birth?"
+msgid "Enter a date of birth before %(max)s"
 msgstr ""
 
 #. Answer error message
@@ -2292,14 +2326,38 @@ msgstr ""
 
 #. Answer error message
 msgctxt "When did you most recently arrive to live in the United Kingdom?"
-msgid "Enter a date of arrival"
+msgid "Enter a valid date of arrival"
+msgstr ""
+
+#. Answer error message
+msgctxt "When did you most recently arrive to live in the United Kingdom?"
+msgid "Enter a date of arrival that is after your date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt "When did you most recently arrive to live in the United Kingdom?"
+msgid "Enter a date of arrival that is in the past"
 msgstr ""
 
 #. Answer error message
 msgctxt ""
 "When did <em>{person_name}</em> most recently arrive to live in the "
 "United Kingdom?"
-msgid "Enter a date of arrival"
+msgid "Enter a valid date of arrival"
+msgstr ""
+
+#. Answer error message
+msgctxt ""
+"When did <em>{person_name}</em> most recently arrive to live in the "
+"United Kingdom?"
+msgid "Enter a date of arrival that is after their date of birth"
+msgstr ""
+
+#. Answer error message
+msgctxt ""
+"When did <em>{person_name}</em> most recently arrive to live in the "
+"United Kingdom?"
+msgid "Enter a date of arrival that is in the past"
 msgstr ""
 
 #. Answer

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-15 08:41+0100\n"
+"POT-Creation-Date: 2020-10-15 08:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2331,7 +2331,7 @@ msgstr ""
 
 #. Answer error message
 msgctxt "When did you most recently arrive to live in the United Kingdom?"
-msgid "Enter a date of arrival that is after their date of birth"
+msgid "Enter a date of arrival that is after your date of birth"
 msgstr ""
 
 #. Answer error message

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-14 12:03+0100\n"
+"POT-Creation-Date: 2020-10-15 08:41+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2331,7 +2331,7 @@ msgstr ""
 
 #. Answer error message
 msgctxt "When did you most recently arrive to live in the United Kingdom?"
-msgid "Enter a date of arrival that is after your date of birth"
+msgid "Enter a date of arrival that is after their date of birth"
 msgstr ""
 
 #. Answer error message


### PR DESCRIPTION
### What is the context of this PR?

This changes custom validation error messages as described on [Trello card](https://trello.com/c/fH7EZwVM). 

### How to review

Use quick launch schemas below and checklist attached to [Trello card](https://trello.com/c/fH7EZwVM).

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-validation-content/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-validation-content/schemas/en/census_individual_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-validation-content/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-validation-content/schemas/en/census_individual_gb_nir.json)
