### PR TITLE
Fix NISRA age based routing

### DIFF
--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_health_conditions.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_health_conditions.jsonnet
@@ -100,7 +100,7 @@ local proxyTitle = {
     {
       goto: {
         block: 'look-after-or-support-others',
-        when: [rules.schoolYear5AndOver],
+        when: [rules.over5],
       },
     },
     {

--- a/source/jsonnet/northern-ireland/lib/common_rules.libsonnet
+++ b/source/jsonnet/northern-ireland/lib/common_rules.libsonnet
@@ -69,16 +69,6 @@
       },
     },
   },
-  schoolYear5AndOver: {
-    id: 'date-of-birth-answer',
-    condition: 'less than or equal to',
-    date_comparison: {
-      value: '2020-06-30',
-      offset_by: {
-        years: -5,
-      },
-    },
-  },
   mainJob: {
     id: 'employment-status-last-seven-days-answer-exclusive',
     condition: 'not set',


### PR DESCRIPTION
### What is the context of this PR?

This fixes the routing on `other-health-conditions` question in NISRA HH/HI so it routes to `look-after-or-support-others` based on date of birth and census date. For more details check [this Trello card](https://trello.com/c/M7q42is7).

### How to review

Check two different dates of birth: before or equal to 21/03/2016 and one later than 21/03/2016. They should route differently(`look-after-or-support-others` for 5 and over, summary for less than 5).

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/fix-nisra-dob-routing/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/fix-nisra-dob-routing/schemas/en/census_individual_gb_nir.json)
