### PR TITLE
Make study-location-type mandatory

### DIFF
--- a/source/jsonnet/northern-ireland/individual/blocks/school/study_location_type.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/school/study_location_type.jsonnet
@@ -11,7 +11,7 @@ local question(title, description) = {
   answers: [
     {
       id: 'study-location-type-answer',
-      mandatory: false,
+      mandatory: true,
       options: [
         {
           label: 'At a campus or school',


### PR DESCRIPTION
### What is the context of this PR?

Adds mandatory validation to the study-location-type question for the NI schemas.

### How to review

Check that the study-location-type question is mandatory.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/make-study-location-mandatory/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/make-study-location-mandatory/schemas/en/census_individual_gb_nir.json)
