### PR TITLE
Fix visitor usual address details question text

### DIFF
--- a/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_details.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_details.jsonnet
@@ -9,7 +9,7 @@ local rules = import 'rules.libsonnet';
   question: {
     id: 'visitor-usual-address-details-question',
     title: {
-      text: 'What is <em>{person_name_possessive}</em> usual UK address',
+      text: 'What is <em>{person_name_possessive}</em> usual UK address?',
       placeholders: [
         placeholders.personNamePossessive,
       ],

--- a/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_details.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_details.jsonnet
@@ -9,7 +9,7 @@ local rules = import 'rules.libsonnet';
   question: {
     id: 'visitor-usual-address-details-question',
     title: {
-      text: 'Enter details of <em>{person_name_possessive}</em> usual UK address',
+      text: 'What is <em>{person_name_possessive}</em> usual UK address',
       placeholders: [
         placeholders.personNamePossessive,
       ],

--- a/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_details.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_details.jsonnet
@@ -9,7 +9,7 @@ local rules = import 'rules.libsonnet';
   question: {
     id: 'visitor-usual-address-details-question',
     title: {
-      text: 'What is <em>{person_name_possessive}</em> usual UK address',
+      text: 'What is <em>{person_name_possessive}</em> usual UK address?',
       placeholders: [
         placeholders.personNamePossessive,
       ],

--- a/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_details.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_details.jsonnet
@@ -9,7 +9,7 @@ local rules = import 'rules.libsonnet';
   question: {
     id: 'visitor-usual-address-details-question',
     title: {
-      text: 'Enter details of <em>{person_name_possessive}</em> usual UK address',
+      text: 'What is <em>{person_name_possessive}</em> usual UK address',
       placeholders: [
         placeholders.personNamePossessive,
       ],

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-09 14:58+0000\n"
+"POT-Creation-Date: 2020-11-09 16:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1792,7 +1792,7 @@ msgid "What is <em>{person_name_possessive}</em> usual address?"
 msgstr ""
 
 #. Question text
-msgid "What is <em>{person_name_possessive}</em> usual UK address"
+msgid "What is <em>{person_name_possessive}</em> usual UK address?"
 msgstr ""
 
 #. Question text

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-04 13:26+0000\n"
+"POT-Creation-Date: 2020-11-09 14:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1792,7 +1792,7 @@ msgid "What is <em>{person_name_possessive}</em> usual address?"
 msgstr ""
 
 #. Question text
-msgid "Enter details of <em>{person_name_possessive}</em> usual UK address"
+msgid "What is <em>{person_name_possessive}</em> usual UK address"
 msgstr ""
 
 #. Question text

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-04 13:26+0000\n"
+"POT-Creation-Date: 2020-11-09 14:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1932,7 +1932,7 @@ msgid "What is <em>{person_name_possessive}</em> usual address?"
 msgstr ""
 
 #. Question text
-msgid "Enter details of <em>{person_name_possessive}</em> usual UK address"
+msgid "What is <em>{person_name_possessive}</em> usual UK address"
 msgstr ""
 
 #. Question text

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-09 14:58+0000\n"
+"POT-Creation-Date: 2020-11-09 16:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1932,7 +1932,7 @@ msgid "What is <em>{person_name_possessive}</em> usual address?"
 msgstr ""
 
 #. Question text
-msgid "What is <em>{person_name_possessive}</em> usual UK address"
+msgid "What is <em>{person_name_possessive}</em> usual UK address?"
 msgstr ""
 
 #. Question text


### PR DESCRIPTION
### What is the context of this PR?

This fixes question text on `visitor-usual-address-details` in both NI and ENG/WLS HH schemas(CCS is already done). Check [trello card](https://trello.com/c/f74UKtwb) for details.

### How to review

Check HH NI and ENG/WLS schemas `visitor-usual-address-details` below.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_nir.json)
