### PR TITLE
Add unrelated block actions

### DIFF
--- a/source/jsonnet/england-wales/household/blocks/relationships/relationships_collector.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/relationships/relationships_collector.jsonnet
@@ -36,6 +36,9 @@ local unrelatedNoOption(isPrimary) = (
   if isPrimary then {
     label: 'No, none of these people are related to me',
     value: 'No, none of these people are related to me',
+    action: {
+      type: 'AddUnrelatedRelationships',
+    },
   } else {
     label: {
       text: 'No, none of these people are related to {person_name}',
@@ -44,6 +47,9 @@ local unrelatedNoOption(isPrimary) = (
       ],
     },
     value: 'No, none of these people are related to {person_name}',
+    action: {
+      type: 'AddUnrelatedRelationships',
+    },
   }
 );
 
@@ -67,6 +73,9 @@ local unrelatedQuestion(isPrimary) = {
         {
           label: 'Yes',
           value: 'Yes',
+          action: {
+            type: 'RemoveUnrelatedRelationships',
+          },
         },
         unrelatedNoOption(isPrimary),
       ],

--- a/source/jsonnet/northern-ireland/household/blocks/relationships/relationships_collector.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/relationships/relationships_collector.jsonnet
@@ -35,6 +35,9 @@ local unrelatedNoOption(isPrimary) = (
   if isPrimary then {
     label: 'No, none of these people are related to me',
     value: 'No, none of these people are related to me',
+    action: {
+      type: 'AddUnrelatedRelationships',
+    },
   } else {
     label: {
       text: 'No, none of these people are related to {person_name}',
@@ -43,6 +46,9 @@ local unrelatedNoOption(isPrimary) = (
       ],
     },
     value: 'No, none of these people are related to {person_name}',
+    action: {
+      type: 'AddUnrelatedRelationships',
+    },
   }
 );
 
@@ -66,6 +72,9 @@ local unrelatedQuestion(isPrimary) = {
         {
           label: 'Yes',
           value: 'Yes',
+          action: {
+            type: 'RemoveUnrelatedRelationships',
+          },
         },
         unrelatedNoOption(isPrimary),
       ],


### PR DESCRIPTION
### What is the context of this PR?

Adds the required actions for the unrelated block to work, now that https://github.com/ONSdigital/eq-questionnaire-runner/pull/389 has merged.

### How to review

Test the unrelated questions work in the household schemas.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-unrelated-block-actions/schemas/en/census_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-unrelated-block-actions/schemas/en/census_household_gb_nir.json)