### PR TITLE
Update mainly-work-in-uk routing rules

### DIFF
--- a/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_in_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_in_uk.jsonnet
@@ -93,6 +93,22 @@ local question(isProxy) = {
     },
     {
       goto: {
+        block: 'workplace-address',
+        when: [
+          {
+            id: 'workplace-type-answer',
+            condition: 'not set',
+          },
+          {
+            id: 'mainly-work-in-uk-answer',
+            condition: 'equals',
+            value: 'Yes',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
         block: 'depot-address',
         when: [
           {

--- a/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_in_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_in_uk.jsonnet
@@ -69,7 +69,8 @@ local question(isProxy) = {
           },
           {
             id: 'mainly-work-in-uk-answer',
-            condition: 'not set',
+            condition: 'not equals',
+            value: 'No',
           },
         ],
       },
@@ -87,22 +88,6 @@ local question(isProxy) = {
             id: 'mainly-work-in-uk-answer',
             condition: 'not equals',
             value: 'No',
-          },
-        ],
-      },
-    },
-    {
-      goto: {
-        block: 'workplace-address',
-        when: [
-          {
-            id: 'workplace-type-answer',
-            condition: 'not set',
-          },
-          {
-            id: 'mainly-work-in-uk-answer',
-            condition: 'equals',
-            value: 'Yes',
           },
         ],
       },


### PR DESCRIPTION
### What is the context of this PR?

The `mainly-work-in-uk` routing rules have been updated so that it routes to `workplace-address`  when workplace-type is unanswered and mainly-work-in-uk is yes or unanswered

### How to review

Check that the new routing rule matches the above/the trello card.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-mainly-work-in-uk-routing/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-mainly-work-in-uk-routing/schemas/en/census_individual_gb_eng.json)
