### PR TITLE
Add middle names to individual-coronavirus-circumstances page

### DIFF
--- a/source/jsonnet/england-wales/household/blocks/individual/individual_coronavirus_circumstances.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/individual/individual_coronavirus_circumstances.jsonnet
@@ -11,7 +11,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
         description: {
           text: 'Circumstances for <strong>{person_name}</strong> may have changed during the coronavirus pandemic. Answer all questions based on the situation as it is now.',
           placeholders: [
-            placeholders.personName(),
+            placeholders.personName(includeMiddleNames='if_is_same_name'),
           ],
         },
       },


### PR DESCRIPTION
### What is the context of this PR?

Adds the middle name of any person to the piped name on `individual-coronavirus-circumstances` interstitial page  (Household Eng/Wls only), if they share the same first and last names with anyone else in the household.

### How to review

Use the ENG/WLS Census household schema and check that the middle name is displayed/not displayed as described in the scenarios listed on the Trello card.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/add-middle-names-to-interstitial-page/schemas/en/census_household_gb_eng.json)
