### PR TITLE
Remove full stops from business-name question description (Eng/Wls)

### DIFF
--- a/source/jsonnet/england-wales/individual/blocks/employment/business_name.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/business_name.jsonnet
@@ -43,7 +43,7 @@ local proxyTitle = {
 local proxyDescription = 'If they are self-employed in their own business, give the business name';
 
 local pastNonProxyTitle = 'What was the name of the organisation or business you worked for?';
-local pastNonProxyDescription = 'If you were self-employed in your own business, give the business name.';
+local pastNonProxyDescription = 'If you were self-employed in your own business, give the business name';
 
 local pastProxyTitle = {
   text: 'What was the name of the organisation or business <em>{person_name}</em> worked for?',
@@ -51,7 +51,7 @@ local pastProxyTitle = {
     placeholders.personName(),
   ],
 };
-local pastProxyDescription = 'If they were self-employed in their own business, give the business name.';
+local pastProxyDescription = 'If they were self-employed in their own business, give the business name';
 
 local nonProxyoption = 'No organisation or work for a private individual';
 local proxyOption = 'No organisation or works for a private individual';

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-23 11:06+0000\n"
+"POT-Creation-Date: 2020-11-23 14:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2191,14 +2191,14 @@ msgstr ""
 
 #. Question description
 msgctxt "What was the name of the organisation or business you worked for?"
-msgid "If you were self-employed in your own business, give the business name."
+msgid "If you were self-employed in your own business, give the business name"
 msgstr ""
 
 #. Question description
 msgctxt ""
 "What was the name of the organisation or business <em>{person_name}</em> "
 "worked for?"
-msgid "If they were self-employed in their own business, give the business name."
+msgid "If they were self-employed in their own business, give the business name"
 msgstr ""
 
 #. Question description

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-23 11:06+0000\n"
+"POT-Creation-Date: 2020-11-23 14:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1620,14 +1620,14 @@ msgstr ""
 
 #. Question description
 msgctxt "What was the name of the organisation or business you worked for?"
-msgid "If you were self-employed in your own business, give the business name."
+msgid "If you were self-employed in your own business, give the business name"
 msgstr ""
 
 #. Question description
 msgctxt ""
 "What was the name of the organisation or business <em>{person_name}</em> "
 "worked for?"
-msgid "If they were self-employed in their own business, give the business name."
+msgid "If they were self-employed in their own business, give the business name"
 msgstr ""
 
 #. Question description


### PR DESCRIPTION
### What is the context of this PR?

Full stops need to be removed from the question description for `business-name` (Eng/Wls) (HH/HI).

### How to review

Check that the full stops have been removed.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/remove-full-stops/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/remove-full-stops/schemas/en/census_individual_gb_eng.json)
