### PR TITLE
Update to lookup suggestions data v5.2.0

### DIFF
--- a/scripts/resolve_suggestions_urls.py
+++ b/scripts/resolve_suggestions_urls.py
@@ -8,7 +8,7 @@ import coloredlogs
 from jsonpath_rw import parse
 from jsonpointer import set_pointer
 
-SUGGESTIONS_URL_BASE = "https://cdn.eq.census-gcp.onsdigital.uk/data/v5.1.0"
+SUGGESTIONS_URL_BASE = "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.2.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What is the context of this PR?

Updates the lookup suggestions data to v5.2.0. This uses minified JSON and uses cached and gzipped files.

The file location on the CDN has changed from `data` to `eq-lookup-suggestions-data`.

### How to review

Verify lookups work in runner.

### Checklist

- [-] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-v5.2.0-lookup-suggestions-data/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-v5.2.0-lookup-suggestions-data/schemas/en/census_individual_gb_eng.json)

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-v5.2.0-lookup-suggestions-data/schemas/en/ccs_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-v5.2.0-lookup-suggestions-data/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-v5.2.0-lookup-suggestions-data/schemas/en/census_individual_gb_nir.json)
