### PR TITLE
Update suggestions base url to v5.3.0

### DIFF
--- a/scripts/resolve_suggestions_urls.py
+++ b/scripts/resolve_suggestions_urls.py
@@ -8,7 +8,7 @@ import coloredlogs
 from jsonpath_rw import parse
 from jsonpointer import set_pointer
 
-SUGGESTIONS_URL_BASE = "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.2.0"
+SUGGESTIONS_URL_BASE = "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What is the context of this PR?

Updates the lookup suggestions url to version 5.3.0 in line with the latest release.

### How to review

Check that the lookup suggestions data contains the latest [changes](https://github.com/ONSdigital/eq-lookup-suggestions-data/releases/tag/v5.3.0)

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-suggestions-url/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-suggestions-url/schemas/en/census_individual_gb_nir.json)
