### PR TITLE
Nest lookups suggestions urls

### DIFF
--- a/scripts/resolve_suggestions_urls.py
+++ b/scripts/resolve_suggestions_urls.py
@@ -26,18 +26,18 @@ def json_path_to_pointer(json_path):
 
 
 def find_suggestion_urls(data):
-    json_path = parse("$..suggestions.url")
+    json_path = parse("$..suggestions")
     for match in json_path.find(data):
         suggestions_url = match.value
-        if "suggestions_url_root" in suggestions_url:
+        if "suggestions_url_root" in suggestions_url["url"]:
             yield match
 
 
 def replace_suggestions_urls(data, replacement_url_root) -> int:
     replaced_pointer_count = 0
     for match in find_suggestion_urls(data):
-        pointer = json_path_to_pointer(str(match.full_path))
-        replacement_url = match.value.format(suggestions_url_root=replacement_url_root)
+        pointer = json_path_to_pointer(f"{str(match.full_path)}.url")
+        replacement_url = match.value['url'].format(suggestions_url_root=replacement_url_root)
         set_pointer(data, pointer, replacement_url)
         replaced_pointer_count += 1
     return replaced_pointer_count
@@ -48,7 +48,7 @@ def remove_suggestions_urls(data) -> int:
     for match in find_suggestion_urls(data):
         parent_pointer = json_path_to_pointer(str(match.context.full_path))
         parent_object = match.context.value
-        del parent_object["url"]
+        del parent_object["suggestions"]
         set_pointer(data, parent_pointer, parent_object)
 
         removed_pointer_count += 1

--- a/scripts/resolve_suggestions_urls.py
+++ b/scripts/resolve_suggestions_urls.py
@@ -26,7 +26,7 @@ def json_path_to_pointer(json_path):
 
 
 def find_suggestion_urls(data):
-    json_path = parse("$..suggestions_url")
+    json_path = parse("$..url")
     for match in json_path.find(data):
         suggestions_url = match.value
         if "suggestions_url_root" in suggestions_url:
@@ -48,7 +48,7 @@ def remove_suggestions_urls(data) -> int:
     for match in find_suggestion_urls(data):
         parent_pointer = json_path_to_pointer(str(match.context.full_path))
         parent_object = match.context.value
-        del parent_object["suggestions_url"]
+        del parent_object["url"]
         set_pointer(data, parent_pointer, parent_object)
 
         removed_pointer_count += 1

--- a/scripts/resolve_suggestions_urls.py
+++ b/scripts/resolve_suggestions_urls.py
@@ -26,7 +26,7 @@ def json_path_to_pointer(json_path):
 
 
 def find_suggestion_urls(data):
-    json_path = parse("$..url")
+    json_path = parse("$..suggestions.url")
     for match in json_path.find(data):
         suggestions_url = match.value
         if "suggestions_url_root" in suggestions_url:

--- a/scripts/resolve_suggestions_urls.py
+++ b/scripts/resolve_suggestions_urls.py
@@ -28,8 +28,8 @@ def json_path_to_pointer(json_path):
 def find_suggestion_urls(data):
     json_path = parse("$..suggestions")
     for match in json_path.find(data):
-        suggestions_url = match.value
-        if "suggestions_url_root" in suggestions_url["url"]:
+        suggestions_url = match.value["url"]
+        if "suggestions_url_root" in suggestions_url:
             yield match
 
 

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-tag=lookups-allow-multiple-selection
+tag=latest
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-tag=latest
+tag=lookups-allow-multiple-selection
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_country.jsonnet
+++ b/source/jsonnet/england-wales/household/blocks/visitor/visitor_usual_address_country.jsonnet
@@ -22,7 +22,7 @@ local rules = import 'rules.libsonnet';
         label: 'Current name of country',
         description: 'Enter your own answer or select from suggestions',
         mandatory: false,
-        suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+        suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
         type: 'TextField',
         max_length: 100,
       },

--- a/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/employment/mainly_work_outside_uk.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_asian_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_asian_other.jsonnet
@@ -22,7 +22,7 @@ local question(isProxy) = (
         description: 'Enter your own answer or select from suggestions',
         max_length: 100,
         mandatory: false,
-        suggestions_url: '{suggestions_url_root}/ethnic-groups.json',
+        suggestions: { url: '{suggestions_url_root}/ethnic-groups.json' },
         type: 'TextField',
       },
     ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_african.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_african.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/ethnic-groups.json',
+      suggestions: { url: '{suggestions_url_root}/ethnic-groups.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_black_other.jsonnet
@@ -13,7 +13,7 @@ local question(title, region_code) = (
         description: 'Enter your own answer or select from suggestions',
         max_length: 100,
         mandatory: false,
-        suggestions_url: '{suggestions_url_root}/ethnic-groups.json',
+        suggestions: { url: '{suggestions_url_root}/ethnic-groups.json' },
         type: 'TextField',
       },
     ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_other_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/ethnic-groups.json',
+      suggestions: { url: '{suggestions_url_root}/ethnic-groups.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_white_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/ethnic_group_white_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/ethnic-groups.json',
+      suggestions: { url: '{suggestions_url_root}/ethnic-groups.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_main_language.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_main_language.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/languages.json',
+      suggestions: { url: '{suggestions_url_root}/languages.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/national-identities.json',
+      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/national-identities.json',
+      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/passport-countries.json',
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/passport-countries.json',
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/religion_other.jsonnet
@@ -19,7 +19,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/religions.json',
+      suggestions: { url: '{suggestions_url_root}/religions.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/another_address_outside_uk.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: true,
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       type: 'TextField',
       validation: {
         messages: {

--- a/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_country.jsonnet
+++ b/source/jsonnet/northern-ireland/household/blocks/visitor/visitor_usual_address_country.jsonnet
@@ -21,7 +21,7 @@ local rules = import 'rules.libsonnet';
         label: 'Current name of country',
         description: 'Enter your own answer or select from suggestions',
         mandatory: false,
-        suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+        suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
         type: 'TextField',
         max_length: 100,
       },

--- a/source/jsonnet/northern-ireland/individual/blocks/employment/workplace_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/employment/workplace_country.jsonnet
@@ -10,7 +10,7 @@ local question(title) = {
       id: 'workplace-country-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       mandatory: false,
       type: 'TextField',
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/address_one_year_ago_outside_uk.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/childhood_religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/childhood_religion_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/religions.json',
+      suggestions: { url: '{suggestions_url_root}/religions.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/country_of_birth_elsewhere.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/ethnic_group_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/ethnic_group_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/ethnic-groups.json',
+      suggestions: { url: '{suggestions_url_root}/ethnic-groups.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_main_language.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_main_language.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/languages.json',
+      suggestions: { url: '{suggestions_url_root}/languages.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/national-identities.json',
+      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/national-identities.json',
+      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/passport-countries.json',
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/passport-countries.json',
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/religion_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions_url: '{suggestions_url_root}/religions.json',
+      suggestions: { url: '{suggestions_url_root}/religions.json' },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/personal-details/term_time_address_country_outside_uk.jsonnet
@@ -10,7 +10,7 @@ local question(title) = {
       id: 'term-time-address-country-outside-uk-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       mandatory: false,
       type: 'TextField',
     },

--- a/source/jsonnet/northern-ireland/individual/blocks/school/study_location_country.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/school/study_location_country.jsonnet
@@ -10,7 +10,7 @@ local question(title) = {
       id: 'study-location-country-answer',
       label: 'Current name of country',
       description: 'Enter your own answer or select from suggestions',
-      suggestions_url: '{suggestions_url_root}/countries-of-birth.json',
+      suggestions: { url: '{suggestions_url_root}/countries-of-birth.json' },
       mandatory: false,
       type: 'TextField',
     },

--- a/translations/ccs_household_gb_wls.pot
+++ b/translations/ccs_household_gb_wls.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-12-07 09:43+0000\n"
+"POT-Creation-Date: 2021-01-07 15:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/translations/census_communal_establishment_gb_wls.pot
+++ b/translations/census_communal_establishment_gb_wls.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-12 15:29+0000\n"
+"POT-Creation-Date: 2021-01-07 15:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-12-10 15:44+0000\n"
+"POT-Creation-Date: 2021-01-07 15:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-12-04 13:57+0000\n"
+"POT-Creation-Date: 2021-01-07 15:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/translations/census_individual_gb_nir.pot
+++ b/translations/census_individual_gb_nir.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-12-10 15:44+0000\n"
+"POT-Creation-Date: 2021-01-07 15:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-12-04 07:12+0000\n"
+"POT-Creation-Date: 2021-01-07 15:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
### What is the context of this PR?

This adds new nested suggestions format to schemas and `resolve_suggestions_urls` script introduced in [this validator PR](https://github.com/ONSdigital/eq-questionnaire-validator/pull/86). This change is described on [Trello card](https://trello.com/c/RqJlAYzx).

### How to review

Describe the steps required to test the changes (include screenshots if appropriate).

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_individual_gb_eng.json)

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/ccs_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_individual_gb_nir.json)
