### PR TITLE
Add allow multiple selection in census schemas

### DIFF
--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
+      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -19,7 +19,10 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/national-identities.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
+      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -19,7 +19,10 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/national-identities.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -19,7 +19,10 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/passport-countries.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -19,7 +19,7 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -19,7 +19,10 @@ local question(title, guidance) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/passport-countries.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
+      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identities.jsonnet
@@ -12,7 +12,10 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/national-identities.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json' },
+      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/other_national_identity.jsonnet
@@ -12,7 +12,10 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/national-identities.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/national-identities.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -12,7 +12,10 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/passport-countries.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_additional_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -12,7 +12,10 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
+      suggestions: {
+        url: '{suggestions_url_root}/passport-countries.json',
+        allow_multiple: true,
+      },
       type: 'TextField',
     },
   ],

--- a/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/identity-and-health/passports_other.jsonnet
@@ -12,7 +12,7 @@ local question(title) = {
       description: 'Enter your own answer or select from suggestions',
       max_length: 100,
       mandatory: false,
-      suggestions: { url: '{suggestions_url_root}/passport-countries.json' },
+      suggestions: { url: '{suggestions_url_root}/passport-countries.json', allow_multiple: true },
       type: 'TextField',
     },
   ],


### PR DESCRIPTION
### What is the context of this PR?

This adds `allow_multiple` entries booleans on the following look-up pages: `passports-other`, `passports-additional-other`, `other-national-identity`, `other-national-identities`. This change is described on [Trello](https://trello.com/c/xGiARTdL) and it is a follow up to this [PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/487).

### How to review

Run validation, check if HH/HI schemas for ENG/WLS and NI (passports-other, passports-additional-other, other-national-identity, other-national-identities look-up pages) allow multiple selection.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/allow-multiple-selection-in-census-schemas/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/allow-multiple-selection-in-census-schemas/schemas/en/census_individual_gb_eng.json)


#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/allow-multiple-selection-in-census-schemas/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/allow-multiple-selection-in-census-schemas/schemas/en/census_individual_gb_nir.json)
