### PR TITLE
Fix "other qualifications" question content in NISRA HH/HI

### DIFF
--- a/source/jsonnet/northern-ireland/individual/blocks/qualifications/other_qualifications.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/qualifications/other_qualifications.jsonnet
@@ -15,7 +15,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        description: 'Include qualifications achieved either within or outside of Northern Ireland',
+        description: 'Include qualifications achieved either within or outside Northern Ireland',
       },
     ],
   },

--- a/source/jsonnet/northern-ireland/individual/blocks/qualifications/other_qualifications.jsonnet
+++ b/source/jsonnet/northern-ireland/individual/blocks/qualifications/other_qualifications.jsonnet
@@ -1,7 +1,7 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import 'rules.libsonnet';
 
-local nonProxyTitle = 'Have you achieved any other qualifications, either within or outside of Northern Ireland?';
+local nonProxyTitle = 'Have you achieved any other qualifications?';
 local proxyTitle = {
   text: 'Has <em>{person_name}</em> achieved any other qualifications?',
   placeholders: [
@@ -12,6 +12,13 @@ local proxyTitle = {
 local question(title) = {
   id: 'other-qualifications-question',
   title: title,
+  guidance: {
+    contents: [
+      {
+        description: 'Include qualifications achieved either within or outside of Northern Ireland',
+      },
+    ],
+  },
   type: 'General',
   answers: [
     {

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-01-07 15:58+0000\n"
+"POT-Creation-Date: 2021-01-15 07:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1402,9 +1402,7 @@ msgid "Has <em>{person_name}</em> achieved an NVQ or equivalent qualification?"
 msgstr ""
 
 #. Question text
-msgid ""
-"Have you achieved any other qualifications, either within or outside of "
-"Northern Ireland?"
+msgid "Have you achieved any other qualifications?"
 msgstr ""
 
 #. Question text
@@ -2446,6 +2444,20 @@ msgstr ""
 msgctxt "Has <em>{person_name}</em> achieved an NVQ or equivalent qualification?"
 msgid ""
 "Include equivalent qualifications achieved anywhere outside Northern "
+"Ireland"
+msgstr ""
+
+#. Question guidance description
+msgctxt "Have you achieved any other qualifications?"
+msgid ""
+"Include qualifications achieved either within or outside of Northern "
+"Ireland"
+msgstr ""
+
+#. Question guidance description
+msgctxt "Has <em>{person_name}</em> achieved any other qualifications?"
+msgid ""
+"Include qualifications achieved either within or outside of Northern "
 "Ireland"
 msgstr ""
 
@@ -5560,16 +5572,12 @@ msgid "None of these apply"
 msgstr ""
 
 #. Answer option
-msgctxt ""
-"Have you achieved any other qualifications, either within or outside of "
-"Northern Ireland?"
+msgctxt "Have you achieved any other qualifications?"
 msgid "Yes"
 msgstr ""
 
 #. Answer option
-msgctxt ""
-"Have you achieved any other qualifications, either within or outside of "
-"Northern Ireland?"
+msgctxt "Have you achieved any other qualifications?"
 msgid "No qualifications"
 msgstr ""
 

--- a/translations/census_household_gb_nir.pot
+++ b/translations/census_household_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-01-15 07:51+0000\n"
+"POT-Creation-Date: 2021-01-15 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2449,16 +2449,12 @@ msgstr ""
 
 #. Question guidance description
 msgctxt "Have you achieved any other qualifications?"
-msgid ""
-"Include qualifications achieved either within or outside of Northern "
-"Ireland"
+msgid "Include qualifications achieved either within or outside Northern Ireland"
 msgstr ""
 
 #. Question guidance description
 msgctxt "Has <em>{person_name}</em> achieved any other qualifications?"
-msgid ""
-"Include qualifications achieved either within or outside of Northern "
-"Ireland"
+msgid "Include qualifications achieved either within or outside Northern Ireland"
 msgstr ""
 
 #. Question guidance description

--- a/translations/census_individual_gb_nir.pot
+++ b/translations/census_individual_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-01-07 15:58+0000\n"
+"POT-Creation-Date: 2021-01-15 07:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -909,9 +909,7 @@ msgid "Has <em>{person_name}</em> achieved an NVQ or equivalent qualification?"
 msgstr ""
 
 #. Question text
-msgid ""
-"Have you achieved any other qualifications, either within or outside of "
-"Northern Ireland?"
+msgid "Have you achieved any other qualifications?"
 msgstr ""
 
 #. Question text
@@ -1734,6 +1732,20 @@ msgstr ""
 msgctxt "Has <em>{person_name}</em> achieved an NVQ or equivalent qualification?"
 msgid ""
 "Include equivalent qualifications achieved anywhere outside Northern "
+"Ireland"
+msgstr ""
+
+#. Question guidance description
+msgctxt "Have you achieved any other qualifications?"
+msgid ""
+"Include qualifications achieved either within or outside of Northern "
+"Ireland"
+msgstr ""
+
+#. Question guidance description
+msgctxt "Has <em>{person_name}</em> achieved any other qualifications?"
+msgid ""
+"Include qualifications achieved either within or outside of Northern "
 "Ireland"
 msgstr ""
 
@@ -4009,16 +4021,12 @@ msgid "None of these apply"
 msgstr ""
 
 #. Answer option
-msgctxt ""
-"Have you achieved any other qualifications, either within or outside of "
-"Northern Ireland?"
+msgctxt "Have you achieved any other qualifications?"
 msgid "Yes"
 msgstr ""
 
 #. Answer option
-msgctxt ""
-"Have you achieved any other qualifications, either within or outside of "
-"Northern Ireland?"
+msgctxt "Have you achieved any other qualifications?"
 msgid "No qualifications"
 msgstr ""
 

--- a/translations/census_individual_gb_nir.pot
+++ b/translations/census_individual_gb_nir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-01-15 07:51+0000\n"
+"POT-Creation-Date: 2021-01-15 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1737,16 +1737,12 @@ msgstr ""
 
 #. Question guidance description
 msgctxt "Have you achieved any other qualifications?"
-msgid ""
-"Include qualifications achieved either within or outside of Northern "
-"Ireland"
+msgid "Include qualifications achieved either within or outside Northern Ireland"
 msgstr ""
 
 #. Question guidance description
 msgctxt "Has <em>{person_name}</em> achieved any other qualifications?"
-msgid ""
-"Include qualifications achieved either within or outside of Northern "
-"Ireland"
+msgid "Include qualifications achieved either within or outside Northern Ireland"
 msgstr ""
 
 #. Question guidance description


### PR DESCRIPTION
### What is the context of this PR?

This changes direct variant's content of other-qualification question and adds `include` panel so both proxy/non-proxy are the same. It is described on [this Trello card](https://trello.com/c/0DThmtiJ).  New translations need to be added to Crowdin.

### How to review

Check qualifications section's last question (`other-qualifications`) in quick launch schemas below.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-nisra-content/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/change-nisra-content/schemas/en/census_individual_gb_nir.json)
