### PR TITLE
Remove question description from term time location

### DIFF
--- a/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
+++ b/source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
@@ -12,12 +12,6 @@ local title(isProxy) = (
   else 'During term time, where do you usually live?'
 );
 
-local questionDescription(isProxy) = (
-  if isProxy then
-    'If the <strong>coronavirus</strong> pandemic affected their usual term-time address, answer based on their situation as it is now'
-  else 'If the <strong>coronavirus</strong> pandemic affected your usual term-time address, answer based on your situation as it is now'
-);
-
 local answerDescription(isProxy) = (
   if isProxy then
     'Their answer helps us produce an accurate count of the population during term time. These figures can be used to plan services such as healthcare and transport. This is particularly important in areas with large universities and student populations.'
@@ -28,9 +22,6 @@ local question(options, isProxy) = {
   id: 'term-time-location-question',
   type: 'General',
   title: title(isProxy),
-  description: [
-    questionDescription(isProxy),
-  ],
   answers: [
     {
       id: 'term-time-location-answer',

--- a/translations/census_household_gb_wls.pot
+++ b/translations/census_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-01-07 15:58+0000\n"
+"POT-Creation-Date: 2021-01-15 10:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1981,20 +1981,6 @@ msgctxt ""
 msgid ""
 "This should be a single address and could be more than 30 days in a row "
 "or divided across the year"
-msgstr ""
-
-#. Question description
-msgctxt "During term time, where do you usually live?"
-msgid ""
-"If the <strong>coronavirus</strong> pandemic affected your usual term-"
-"time address, answer based on your situation as it is now"
-msgstr ""
-
-#. Question description
-msgctxt "During term time, where does <em>{person_name}</em> usually live?"
-msgid ""
-"If the <strong>coronavirus</strong> pandemic affected their usual term-"
-"time address, answer based on their situation as it is now"
 msgstr ""
 
 #. Question description

--- a/translations/census_individual_gb_wls.pot
+++ b/translations/census_individual_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-01-07 15:58+0000\n"
+"POT-Creation-Date: 2021-01-15 10:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1411,20 +1411,6 @@ msgctxt ""
 msgid ""
 "This should be a single address and could be more than 30 days in a row "
 "or divided across the year"
-msgstr ""
-
-#. Question description
-msgctxt "During term time, where do you usually live?"
-msgid ""
-"If the <strong>coronavirus</strong> pandemic affected your usual term-"
-"time address, answer based on your situation as it is now"
-msgstr ""
-
-#. Question description
-msgctxt "During term time, where does <em>{person_name}</em> usually live?"
-msgid ""
-"If the <strong>coronavirus</strong> pandemic affected their usual term-"
-"time address, answer based on their situation as it is now"
 msgstr ""
 
 #. Question description


### PR DESCRIPTION
### What is the context of this PR?

Removes the coronavirus guidance from the question description for `term-time-location` (Eng/Wls HH/HI).

### How to review

Check that the question description has been removed.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/remove-content-term-time-location/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/remove-content-term-time-location/schemas/en/census_individual_gb_eng.json)
