### PR TITLE
Remove question description from term time location CCS

### DIFF
--- a/source/jsonnet/england-wales/ccs/blocks/individual/term_time_location.jsonnet
+++ b/source/jsonnet/england-wales/ccs/blocks/individual/term_time_location.jsonnet
@@ -10,25 +10,10 @@ local title(isProxy) = (
   } else 'During term time, where did you usually live?'
 );
 
-local description(isProxy) = (
-  if isProxy then {
-    text: 'If the <strong>coronavirus</strong> pandemic affected their usual term-time address, answer based on their situation on Sunday {census_date}.',
-    placeholders: [
-      placeholders.censusDate,
-    ],
-  } else {
-    text: 'If the <strong>coronavirus</strong> pandemic affected your usual term-time address, answer based on your situation on Sunday {census_date}.',
-    placeholders: [
-      placeholders.censusDate,
-    ],
-  }
-);
-
 local question(options, isProxy) = {
   id: 'term-time-location-question',
   type: 'General',
   title: title(isProxy),
-  description: [description(isProxy)],
   answers: [
     {
       id: 'term-time-location-answer',

--- a/translations/ccs_household_gb_wls.pot
+++ b/translations/ccs_household_gb_wls.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-01-12 15:26+0000\n"
+"POT-Creation-Date: 2021-01-18 15:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -645,20 +645,6 @@ msgctxt ""
 msgid ""
 "This refers to any interaction you might have with public authorities "
 "online, such as DVLA, HMRC, local council or health-related services"
-msgstr ""
-
-#. Question description
-msgctxt "During term time, where did you usually live?"
-msgid ""
-"If the <strong>coronavirus</strong> pandemic affected your usual term-"
-"time address, answer based on your situation on Sunday {census_date}."
-msgstr ""
-
-#. Question description
-msgctxt "During term time, where did <em>{person_name}</em> usually live?"
-msgid ""
-"If the <strong>coronavirus</strong> pandemic affected their usual term-"
-"time address, answer based on their situation on Sunday {census_date}."
 msgstr ""
 
 #. Question description


### PR DESCRIPTION
### What is the context of this PR?

Removes the coronavirus guidance from the question description for `term-time-location` (CCS). The change is described on this [Trello card](https://trello.com/c/57Zsms8r).

### How to review

Check that the question description has been removed.

### Checklist

- [x] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/remove-content-ccs/schemas/en/ccs_household_gb_eng.json)

