### PR TITLE
Add latest CCS welsh translations

### DIFF
--- a/translations/cy/ccs_household_gb_wls_cy.po
+++ b/translations/cy/ccs_household_gb_wls_cy.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: eq-census\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2021-01-13 14:42+0000\n"
-"PO-Revision-Date: 2021-01-19 10:32\n"
+"PO-Revision-Date: 2021-01-20 14:32\n"
 "Last-Translator: \n"
 "Language-Team: Welsh\n"
 "MIME-Version: 1.0\n"
@@ -500,7 +500,7 @@ msgstr "<strong>Bydd unrhyw un arall yn cael cyfweliad ar wahân gan nad ydy’n
 #. Question description
 msgctxt "Did anyone else usually live in your household on Sunday {census_date}?"
 msgid "Remember to only include those people who share cooking facilities <strong>and</strong> share a living room, <strong>or</strong> sitting room, <strong>or</strong> dining area.<p>Anyone else is not part of your household and will be interviewed separately.</p>"
-msgstr "Cofiwch gynnwys dim ond y bobl hynny sy’n rhannu cyfleusterau coginio <strong>ac</strong> yn rhannu ystafell fyw, <strong>neu</strong> lolfa, <strong>neu</strong> le bwyta.<p>Bydd unrhyw berson arall yn cael cyfweliad ar wahân gan nad ydy’n rhan o’ch cartref.</p>"
+msgstr "Cofiwch gynnwys dim ond y bobl hynny sy’n rhannu cyfleusterau coginio <strong>ac</strong> yn rhannu ystafell fyw, <strong>neu</strong> lolfa, <strong>neu</strong> le bwyta.<p>Bydd unrhyw arall yn cael cyfweliad ar wahân gan nad ydy’n rhan o’ch cartref.</p>"
 
 #. Question description
 msgctxt "Are any of these people related to each other?"
@@ -595,7 +595,7 @@ msgstr "Dywedwch wrth yr ymatebwr am ailedrych ar <strong>Gerdyn Dangos 2</stron
 #. Question instruction
 msgctxt "How many visitors were staying overnight at {household_address} on Sunday {census_date}?"
 msgid "Tell the respondent to turn to <strong>Showcard 13</strong> or show them the <strong>Electronic Showcard</strong> below"
-msgstr "Dywedwch wrth yr ymatebwram droi at <strong>Gerdyn Dangos 13</strong> neu dangoswch y <strong>Cerdyn Dangos Electronig</strong> isod iddo"
+msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 13</strong> neu dangoswch y <strong>Cerdyn Dangos Electronig</strong> isod iddo"
 
 #. Question instruction
 msgctxt "How many visitors were staying overnight at {other_address} on Sunday {census_date}?"
@@ -2060,7 +2060,7 @@ msgstr "Gwaith hunangyflogedig neu ar ei liwt ei hun"
 #. Answer option
 msgctxt "During the week of 15 to {census_date}, was <em>{person_name}</em> doing any of the following?"
 msgid "Temporarily away from work ill, on holiday or temporarily laid off"
-msgstr "I ffwrdd o'r gwaith dros dro yn sâl, ar wyliau, neu mae'r unigolyn wedi'i gadw o'r gwaith dros dro am na allai’r y cyflogwr gynnig gwaith ar y pryd"
+msgstr "I ffwrdd o'r gwaith dros dro yn sâl, ar wyliau, neu mae'r unigolyn wedi'i gadw o'r gwaith dros dro am na allai’r cyflogwr gynnig gwaith ar y pryd"
 
 #. Answer option
 msgctxt "During the week of 15 to {census_date}, was <em>{person_name}</em> doing any of the following?"

--- a/translations/cy/ccs_household_gb_wls_cy.po
+++ b/translations/cy/ccs_household_gb_wls_cy.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: eq-census\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2021-01-13 14:42+0000\n"
-"PO-Revision-Date: 2021-01-20 14:32\n"
+"PO-Revision-Date: 2021-01-20 15:07\n"
 "Last-Translator: \n"
 "Language-Team: Welsh\n"
 "MIME-Version: 1.0\n"
@@ -500,7 +500,7 @@ msgstr "<strong>Bydd unrhyw un arall yn cael cyfweliad ar wahân gan nad ydy’n
 #. Question description
 msgctxt "Did anyone else usually live in your household on Sunday {census_date}?"
 msgid "Remember to only include those people who share cooking facilities <strong>and</strong> share a living room, <strong>or</strong> sitting room, <strong>or</strong> dining area.<p>Anyone else is not part of your household and will be interviewed separately.</p>"
-msgstr "Cofiwch gynnwys dim ond y bobl hynny sy’n rhannu cyfleusterau coginio <strong>ac</strong> yn rhannu ystafell fyw, <strong>neu</strong> lolfa, <strong>neu</strong> le bwyta.<p>Bydd unrhyw arall yn cael cyfweliad ar wahân gan nad ydy’n rhan o’ch cartref.</p>"
+msgstr "Cofiwch gynnwys dim ond y bobl hynny sy’n rhannu cyfleusterau coginio <strong>ac</strong> yn rhannu ystafell fyw, <strong>neu</strong> lolfa, <strong>neu</strong> le bwyta.<p>Bydd unrhyw un arall yn cael cyfweliad ar wahân gan nad ydy’n rhan o’ch cartref.</p>"
 
 #. Question description
 msgctxt "Are any of these people related to each other?"


### PR DESCRIPTION
### What is the context of this PR?

Adds the latest Welsh translation for CCS.

### How to review

Check the translations match crowdin

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_individual_gb_eng.json)

- [CCS](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/ccs_household_gb_eng.json)

#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/<branch>/schemas/en/census_individual_gb_nir.json)
