### PR TITLE
Update schemas to use formal CDN

### DIFF
--- a/scripts/resolve_suggestions_urls.py
+++ b/scripts/resolve_suggestions_urls.py
@@ -8,7 +8,7 @@ import coloredlogs
 from jsonpath_rw import parse
 from jsonpointer import set_pointer
 
-SUGGESTIONS_URL_BASE = "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0"
+SUGGESTIONS_URL_BASE = "https://cdn.census.gov.uk/eq-lookup-suggestions-data/v5.3.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What is the context of this PR?
This updates census schemas to point `suggestions_url` at `cdn.census.gov.uk` domain instead of `cdn.eq.census-gcp.onsdigital.uk`.

### How to review 
Check if current version v5.3.0 published data exists and is latest as required by business requirements.

### Checklist

- [ ] Jsonnet files conform to the latest [style guide](/ONSdigital/eq-questionnaire-schemas/blob/master/style_guide.md)

### Quick Launch

#### England

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=H&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-formal-cdn/schemas/en/census_household_gb_eng.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-ENG&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-formal-cdn/schemas/en/census_individual_gb_eng.json)


#### Northern Ireland

- [Household](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-formal-cdn/schemas/en/census_household_gb_nir.json)

- [Individual](https://test-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&form_type=I&region_code=GB-NIR&url=https://storage.googleapis.com/eq-questionnaire-schemas-artifacts/update-to-formal-cdn/schemas/en/census_individual_gb_nir.json)
