### PR TITLE
Remove notify runner job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,20 +61,3 @@ jobs:
           files: schemas.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  notify-runner:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get schema version
-        uses: actions/checkout@v2
-      - run: |
-          GITHUB_REF=`echo ${{ github.ref }}`
-          TAG_CLEAN="${GITHUB_REF/refs\/tags\//}"
-          echo "TAG=$TAG_CLEAN" >> $GITHUB_ENV
-      - name: Notify Runner
-        uses: peter-evans/repository-dispatch@v1.0.0
-        with:
-          token: "${{ secrets.REPO_ACCESS_TOKEN }}"
-          repository: "ONSdigital/eq-questionnaire-runner"
-          event-type: "schemas_release"
-          client-payload: '{"tag": "${{ env.TAG }}"}'


### PR DESCRIPTION
### What is the context of this PR?

This removes 'notify runner' step from new schemas release workflow and is part of [Remove schemas release and autosquash workflows](https://github.com/ONSdigital/eq-questionnaire-runner/pull/592) work in runner, as described on [this Trello](https://trello.com/c/cPTkbmwI).

### How to review

Check that notify runner has been removed, make new release in fork.
