### PR TITLE
Fix to mbs_0158

### DIFF
--- a/schemas/business/en/mbs_0158.json
+++ b/schemas/business/en/mbs_0158.json
@@ -362,7 +362,10 @@
                     "label": "To",
                     "q_code": "12",
                     "maximum": {
-                      "value": "2016-06-12",
+                      "value": {
+                        "source": "metadata",
+                        "identifier": "ref_p_end_date"
+                      },
                       "offset_by": {
                         "days": 20
                       }


### PR DESCRIPTION
### What is the context of this PR?
Fix to `mbs_0158`. Metadata dates were hardcoded for answer `answer20459962-662d-4439-9987-2b89b0ac5479to`. This has not been updated to link to the metadata.

### How to review
- [ ] Check `mbs_0158` and that `answer20459962-662d-4439-9987-2b89b0ac5479to` dates are not hardcoded strings but are now linked to the metadata.
