### PR TITLE
Remove confirmation email

### DIFF
--- a/schemas/business/en/1_0005.json
+++ b/schemas/business/en/1_0005.json
@@ -3368,7 +3368,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0005.json
+++ b/schemas/business/en/1_0005.json
@@ -3368,7 +3368,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0102.json
+++ b/schemas/business/en/1_0102.json
@@ -757,7 +757,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0102.json
+++ b/schemas/business/en/1_0102.json
@@ -757,7 +757,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0112.json
+++ b/schemas/business/en/1_0112.json
@@ -1264,7 +1264,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0112.json
+++ b/schemas/business/en/1_0112.json
@@ -1264,7 +1264,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0203.json
+++ b/schemas/business/en/1_0203.json
@@ -1241,7 +1241,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0203.json
+++ b/schemas/business/en/1_0203.json
@@ -1241,7 +1241,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0205.json
+++ b/schemas/business/en/1_0205.json
@@ -1306,7 +1306,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0205.json
+++ b/schemas/business/en/1_0205.json
@@ -1306,7 +1306,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0213.json
+++ b/schemas/business/en/1_0213.json
@@ -1644,7 +1644,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0213.json
+++ b/schemas/business/en/1_0213.json
@@ -1644,7 +1644,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0215.json
+++ b/schemas/business/en/1_0215.json
@@ -1715,7 +1715,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/1_0215.json
+++ b/schemas/business/en/1_0215.json
@@ -1715,7 +1715,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/2_0001.json
+++ b/schemas/business/en/2_0001.json
@@ -550,7 +550,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/2_0001.json
+++ b/schemas/business/en/2_0001.json
@@ -550,7 +550,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1801.json
+++ b/schemas/business/en/abs_1801.json
@@ -6807,7 +6807,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1801.json
+++ b/schemas/business/en/abs_1801.json
@@ -6807,7 +6807,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1802.json
+++ b/schemas/business/en/abs_1802.json
@@ -2671,7 +2671,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1802.json
+++ b/schemas/business/en/abs_1802.json
@@ -2671,7 +2671,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1803.json
+++ b/schemas/business/en/abs_1803.json
@@ -6522,7 +6522,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1803.json
+++ b/schemas/business/en/abs_1803.json
@@ -6522,7 +6522,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1804.json
+++ b/schemas/business/en/abs_1804.json
@@ -2910,7 +2910,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1804.json
+++ b/schemas/business/en/abs_1804.json
@@ -2910,7 +2910,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1806.json
+++ b/schemas/business/en/abs_1806.json
@@ -5895,7 +5895,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1806.json
+++ b/schemas/business/en/abs_1806.json
@@ -5895,7 +5895,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1807.json
+++ b/schemas/business/en/abs_1807.json
@@ -5928,7 +5928,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1807.json
+++ b/schemas/business/en/abs_1807.json
@@ -5928,7 +5928,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1808.json
+++ b/schemas/business/en/abs_1808.json
@@ -2564,7 +2564,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1808.json
+++ b/schemas/business/en/abs_1808.json
@@ -2564,7 +2564,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1810.json
+++ b/schemas/business/en/abs_1810.json
@@ -2547,7 +2547,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1810.json
+++ b/schemas/business/en/abs_1810.json
@@ -2547,7 +2547,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1811.json
+++ b/schemas/business/en/abs_1811.json
@@ -5921,7 +5921,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1811.json
+++ b/schemas/business/en/abs_1811.json
@@ -5921,7 +5921,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1812.json
+++ b/schemas/business/en/abs_1812.json
@@ -2342,7 +2342,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1812.json
+++ b/schemas/business/en/abs_1812.json
@@ -2342,7 +2342,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1814.json
+++ b/schemas/business/en/abs_1814.json
@@ -2479,7 +2479,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1814.json
+++ b/schemas/business/en/abs_1814.json
@@ -2479,7 +2479,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1815.json
+++ b/schemas/business/en/abs_1815.json
@@ -5807,7 +5807,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1815.json
+++ b/schemas/business/en/abs_1815.json
@@ -5807,7 +5807,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1817.json
+++ b/schemas/business/en/abs_1817.json
@@ -5583,7 +5583,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1817.json
+++ b/schemas/business/en/abs_1817.json
@@ -5583,7 +5583,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1818.json
+++ b/schemas/business/en/abs_1818.json
@@ -2555,7 +2555,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1818.json
+++ b/schemas/business/en/abs_1818.json
@@ -2555,7 +2555,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1819.json
+++ b/schemas/business/en/abs_1819.json
@@ -5628,7 +5628,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1819.json
+++ b/schemas/business/en/abs_1819.json
@@ -5628,7 +5628,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1820.json
+++ b/schemas/business/en/abs_1820.json
@@ -2361,7 +2361,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1820.json
+++ b/schemas/business/en/abs_1820.json
@@ -2361,7 +2361,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1821.json
+++ b/schemas/business/en/abs_1821.json
@@ -5957,7 +5957,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1821.json
+++ b/schemas/business/en/abs_1821.json
@@ -5957,7 +5957,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1823.json
+++ b/schemas/business/en/abs_1823.json
@@ -5601,7 +5601,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1823.json
+++ b/schemas/business/en/abs_1823.json
@@ -5601,7 +5601,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1824.json
+++ b/schemas/business/en/abs_1824.json
@@ -2432,7 +2432,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1824.json
+++ b/schemas/business/en/abs_1824.json
@@ -2432,7 +2432,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1825.json
+++ b/schemas/business/en/abs_1825.json
@@ -6063,7 +6063,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1825.json
+++ b/schemas/business/en/abs_1825.json
@@ -6063,7 +6063,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1826.json
+++ b/schemas/business/en/abs_1826.json
@@ -2486,7 +2486,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1826.json
+++ b/schemas/business/en/abs_1826.json
@@ -2486,7 +2486,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1862.json
+++ b/schemas/business/en/abs_1862.json
@@ -2873,7 +2873,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1862.json
+++ b/schemas/business/en/abs_1862.json
@@ -2873,7 +2873,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1863.json
+++ b/schemas/business/en/abs_1863.json
@@ -6576,7 +6576,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1863.json
+++ b/schemas/business/en/abs_1863.json
@@ -6576,7 +6576,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1864.json
+++ b/schemas/business/en/abs_1864.json
@@ -2715,7 +2715,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1864.json
+++ b/schemas/business/en/abs_1864.json
@@ -2715,7 +2715,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1865.json
+++ b/schemas/business/en/abs_1865.json
@@ -6671,7 +6671,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1865.json
+++ b/schemas/business/en/abs_1865.json
@@ -6671,7 +6671,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1867.json
+++ b/schemas/business/en/abs_1867.json
@@ -6797,7 +6797,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1867.json
+++ b/schemas/business/en/abs_1867.json
@@ -6797,7 +6797,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1871.json
+++ b/schemas/business/en/abs_1871.json
@@ -6224,7 +6224,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1871.json
+++ b/schemas/business/en/abs_1871.json
@@ -6224,7 +6224,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1873.json
+++ b/schemas/business/en/abs_1873.json
@@ -5847,7 +5847,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1873.json
+++ b/schemas/business/en/abs_1873.json
@@ -5847,7 +5847,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1874.json
+++ b/schemas/business/en/abs_1874.json
@@ -2663,7 +2663,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1874.json
+++ b/schemas/business/en/abs_1874.json
@@ -2663,7 +2663,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1875.json
+++ b/schemas/business/en/abs_1875.json
@@ -6521,7 +6521,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1875.json
+++ b/schemas/business/en/abs_1875.json
@@ -6521,7 +6521,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1877.json
+++ b/schemas/business/en/abs_1877.json
@@ -6545,7 +6545,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/abs_1877.json
+++ b/schemas/business/en/abs_1877.json
@@ -6545,7 +6545,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/acas_0002.json
+++ b/schemas/business/en/acas_0002.json
@@ -9609,7 +9609,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/acas_0002.json
+++ b/schemas/business/en/acas_0002.json
@@ -9609,7 +9609,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/acas_0003.json
+++ b/schemas/business/en/acas_0003.json
@@ -9609,7 +9609,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/acas_0003.json
+++ b/schemas/business/en/acas_0003.json
@@ -9609,7 +9609,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/aris_0001.json
+++ b/schemas/business/en/aris_0001.json
@@ -579,7 +579,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/aris_0001.json
+++ b/schemas/business/en/aris_0001.json
@@ -579,7 +579,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/berd_0001.json
+++ b/schemas/business/en/berd_0001.json
@@ -10804,7 +10804,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/berd_0001.json
+++ b/schemas/business/en/berd_0001.json
@@ -10804,7 +10804,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/berd_0006.json
+++ b/schemas/business/en/berd_0006.json
@@ -1568,7 +1568,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/berd_0006.json
+++ b/schemas/business/en/berd_0006.json
@@ -1568,7 +1568,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/blocks_0002.json
+++ b/schemas/business/en/blocks_0002.json
@@ -798,7 +798,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/blocks_0002.json
+++ b/schemas/business/en/blocks_0002.json
@@ -798,7 +798,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/bricks_0002.json
+++ b/schemas/business/en/bricks_0002.json
@@ -901,7 +901,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/bricks_0002.json
+++ b/schemas/business/en/bricks_0002.json
@@ -901,7 +901,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/construction_0001.json
+++ b/schemas/business/en/construction_0001.json
@@ -2903,7 +2903,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/construction_0001.json
+++ b/schemas/business/en/construction_0001.json
@@ -2903,7 +2903,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/construction_0002.json
+++ b/schemas/business/en/construction_0002.json
@@ -3277,7 +3277,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/construction_0002.json
+++ b/schemas/business/en/construction_0002.json
@@ -3277,7 +3277,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_0001.json
+++ b/schemas/business/en/des_0001.json
@@ -6735,7 +6735,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_0001.json
+++ b/schemas/business/en/des_0001.json
@@ -6735,7 +6735,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_0002.json
+++ b/schemas/business/en/des_0002.json
@@ -6735,7 +6735,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_0002.json
+++ b/schemas/business/en/des_0002.json
@@ -6735,7 +6735,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_9001.json
+++ b/schemas/business/en/des_9001.json
@@ -4588,7 +4588,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_9001.json
+++ b/schemas/business/en/des_9001.json
@@ -4588,7 +4588,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_9002.json
+++ b/schemas/business/en/des_9002.json
@@ -4584,7 +4584,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/des_9002.json
+++ b/schemas/business/en/des_9002.json
@@ -4584,7 +4584,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_0009.json
+++ b/schemas/business/en/lcree_0009.json
@@ -12952,7 +12952,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_0009.json
+++ b/schemas/business/en/lcree_0009.json
@@ -12952,7 +12952,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_0010.json
+++ b/schemas/business/en/lcree_0010.json
@@ -12952,7 +12952,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_0010.json
+++ b/schemas/business/en/lcree_0010.json
@@ -12952,7 +12952,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_8009.json
+++ b/schemas/business/en/lcree_8009.json
@@ -9127,7 +9127,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_8009.json
+++ b/schemas/business/en/lcree_8009.json
@@ -9127,7 +9127,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_8010.json
+++ b/schemas/business/en/lcree_8010.json
@@ -12506,7 +12506,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/lcree_8010.json
+++ b/schemas/business/en/lcree_8010.json
@@ -12506,7 +12506,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0106.json
+++ b/schemas/business/en/mbs_0106.json
@@ -616,7 +616,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0106.json
+++ b/schemas/business/en/mbs_0106.json
@@ -616,7 +616,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0111.json
+++ b/schemas/business/en/mbs_0111.json
@@ -614,7 +614,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0111.json
+++ b/schemas/business/en/mbs_0111.json
@@ -614,7 +614,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0117.json
+++ b/schemas/business/en/mbs_0117.json
@@ -648,7 +648,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0117.json
+++ b/schemas/business/en/mbs_0117.json
@@ -648,7 +648,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0123.json
+++ b/schemas/business/en/mbs_0123.json
@@ -689,7 +689,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0123.json
+++ b/schemas/business/en/mbs_0123.json
@@ -689,7 +689,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0158.json
+++ b/schemas/business/en/mbs_0158.json
@@ -1065,7 +1065,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0158.json
+++ b/schemas/business/en/mbs_0158.json
@@ -1065,7 +1065,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0161.json
+++ b/schemas/business/en/mbs_0161.json
@@ -1064,7 +1064,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0161.json
+++ b/schemas/business/en/mbs_0161.json
@@ -1064,7 +1064,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0167.json
+++ b/schemas/business/en/mbs_0167.json
@@ -1095,7 +1095,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0167.json
+++ b/schemas/business/en/mbs_0167.json
@@ -1095,7 +1095,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0173.json
+++ b/schemas/business/en/mbs_0173.json
@@ -1136,7 +1136,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0173.json
+++ b/schemas/business/en/mbs_0173.json
@@ -1136,7 +1136,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0201.json
+++ b/schemas/business/en/mbs_0201.json
@@ -677,7 +677,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0201.json
+++ b/schemas/business/en/mbs_0201.json
@@ -677,7 +677,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0202.json
+++ b/schemas/business/en/mbs_0202.json
@@ -677,7 +677,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0202.json
+++ b/schemas/business/en/mbs_0202.json
@@ -677,7 +677,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0203.json
+++ b/schemas/business/en/mbs_0203.json
@@ -442,7 +442,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0203.json
+++ b/schemas/business/en/mbs_0203.json
@@ -442,7 +442,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0204.json
+++ b/schemas/business/en/mbs_0204.json
@@ -442,7 +442,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0204.json
+++ b/schemas/business/en/mbs_0204.json
@@ -442,7 +442,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0205.json
+++ b/schemas/business/en/mbs_0205.json
@@ -725,7 +725,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0205.json
+++ b/schemas/business/en/mbs_0205.json
@@ -725,7 +725,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0216.json
+++ b/schemas/business/en/mbs_0216.json
@@ -725,7 +725,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0216.json
+++ b/schemas/business/en/mbs_0216.json
@@ -725,7 +725,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0251.json
+++ b/schemas/business/en/mbs_0251.json
@@ -1120,7 +1120,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0251.json
+++ b/schemas/business/en/mbs_0251.json
@@ -1120,7 +1120,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0253.json
+++ b/schemas/business/en/mbs_0253.json
@@ -885,7 +885,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0253.json
+++ b/schemas/business/en/mbs_0253.json
@@ -885,7 +885,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0255.json
+++ b/schemas/business/en/mbs_0255.json
@@ -1175,7 +1175,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0255.json
+++ b/schemas/business/en/mbs_0255.json
@@ -1175,7 +1175,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0817.json
+++ b/schemas/business/en/mbs_0817.json
@@ -612,7 +612,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0817.json
+++ b/schemas/business/en/mbs_0817.json
@@ -612,7 +612,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0823.json
+++ b/schemas/business/en/mbs_0823.json
@@ -612,7 +612,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0823.json
+++ b/schemas/business/en/mbs_0823.json
@@ -612,7 +612,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0867.json
+++ b/schemas/business/en/mbs_0867.json
@@ -1062,7 +1062,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0867.json
+++ b/schemas/business/en/mbs_0867.json
@@ -1062,7 +1062,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0873.json
+++ b/schemas/business/en/mbs_0873.json
@@ -1062,7 +1062,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mbs_0873.json
+++ b/schemas/business/en/mbs_0873.json
@@ -1062,7 +1062,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mcg_0001.json
+++ b/schemas/business/en/mcg_0001.json
@@ -1702,7 +1702,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mcg_0001.json
+++ b/schemas/business/en/mcg_0001.json
@@ -1702,7 +1702,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mcg_0002.json
+++ b/schemas/business/en/mcg_0002.json
@@ -1703,7 +1703,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/mcg_0002.json
+++ b/schemas/business/en/mcg_0002.json
@@ -1703,7 +1703,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qcas_0018.json
+++ b/schemas/business/en/qcas_0018.json
@@ -1205,7 +1205,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qcas_0018.json
+++ b/schemas/business/en/qcas_0018.json
@@ -1205,7 +1205,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qcas_0019.json
+++ b/schemas/business/en/qcas_0019.json
@@ -1204,7 +1204,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qcas_0019.json
+++ b/schemas/business/en/qcas_0019.json
@@ -1204,7 +1204,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qcas_0020.json
+++ b/schemas/business/en/qcas_0020.json
@@ -1265,7 +1265,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qcas_0020.json
+++ b/schemas/business/en/qcas_0020.json
@@ -1265,7 +1265,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qfs_0002.json
+++ b/schemas/business/en/qfs_0002.json
@@ -2306,7 +2306,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qfs_0002.json
+++ b/schemas/business/en/qfs_0002.json
@@ -2306,7 +2306,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/qpses160_0002.json
+++ b/schemas/business/en/qpses160_0002.json
@@ -1235,7 +1235,7 @@
         }
     ],
     "post_submission": {
-        "confirmation_email": true,
+        "confirmation_email": false,
         "feedback": true,
         "view_response": true,
         "guidance": {

--- a/schemas/business/en/qpses160_0002.json
+++ b/schemas/business/en/qpses160_0002.json
@@ -1235,7 +1235,6 @@
         }
     ],
     "post_submission": {
-        "confirmation_email": false,
         "feedback": true,
         "view_response": true,
         "guidance": {

--- a/schemas/business/en/qpses165_0002.json
+++ b/schemas/business/en/qpses165_0002.json
@@ -1222,7 +1222,7 @@
         }
     ],
     "post_submission": {
-        "confirmation_email": true,
+        "confirmation_email": false,
         "feedback": true,
         "view_response": true,
         "guidance": {

--- a/schemas/business/en/qpses165_0002.json
+++ b/schemas/business/en/qpses165_0002.json
@@ -1222,7 +1222,6 @@
         }
     ],
     "post_submission": {
-        "confirmation_email": false,
         "feedback": true,
         "view_response": true,
         "guidance": {

--- a/schemas/business/en/qpses169_0003.json
+++ b/schemas/business/en/qpses169_0003.json
@@ -1221,7 +1221,6 @@
         }
     ],
     "post_submission": {
-        "confirmation_email": false,
         "feedback": true,
         "view_response": true,
         "guidance": {

--- a/schemas/business/en/qpses169_0003.json
+++ b/schemas/business/en/qpses169_0003.json
@@ -1221,7 +1221,7 @@
         }
     ],
     "post_submission": {
-        "confirmation_email": true,
+        "confirmation_email": false,
         "feedback": true,
         "view_response": true,
         "guidance": {

--- a/schemas/business/en/stocks_0001.json
+++ b/schemas/business/en/stocks_0001.json
@@ -1010,7 +1010,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0001.json
+++ b/schemas/business/en/stocks_0001.json
@@ -1010,7 +1010,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0002.json
+++ b/schemas/business/en/stocks_0002.json
@@ -1010,7 +1010,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0002.json
+++ b/schemas/business/en/stocks_0002.json
@@ -1010,7 +1010,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0003.json
+++ b/schemas/business/en/stocks_0003.json
@@ -860,7 +860,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0003.json
+++ b/schemas/business/en/stocks_0003.json
@@ -860,7 +860,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0004.json
+++ b/schemas/business/en/stocks_0004.json
@@ -860,7 +860,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0004.json
+++ b/schemas/business/en/stocks_0004.json
@@ -860,7 +860,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0005.json
+++ b/schemas/business/en/stocks_0005.json
@@ -1276,7 +1276,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0005.json
+++ b/schemas/business/en/stocks_0005.json
@@ -1276,7 +1276,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0006.json
+++ b/schemas/business/en/stocks_0006.json
@@ -1276,7 +1276,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0006.json
+++ b/schemas/business/en/stocks_0006.json
@@ -1276,7 +1276,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0007.json
+++ b/schemas/business/en/stocks_0007.json
@@ -994,7 +994,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0007.json
+++ b/schemas/business/en/stocks_0007.json
@@ -994,7 +994,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0008.json
+++ b/schemas/business/en/stocks_0008.json
@@ -994,7 +994,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0008.json
+++ b/schemas/business/en/stocks_0008.json
@@ -994,7 +994,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0009.json
+++ b/schemas/business/en/stocks_0009.json
@@ -1319,7 +1319,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0009.json
+++ b/schemas/business/en/stocks_0009.json
@@ -1319,7 +1319,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0010.json
+++ b/schemas/business/en/stocks_0010.json
@@ -1319,7 +1319,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0010.json
+++ b/schemas/business/en/stocks_0010.json
@@ -1319,7 +1319,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0011.json
+++ b/schemas/business/en/stocks_0011.json
@@ -856,7 +856,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0011.json
+++ b/schemas/business/en/stocks_0011.json
@@ -856,7 +856,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0012.json
+++ b/schemas/business/en/stocks_0012.json
@@ -856,7 +856,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0012.json
+++ b/schemas/business/en/stocks_0012.json
@@ -856,7 +856,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0013.json
+++ b/schemas/business/en/stocks_0013.json
@@ -1016,7 +1016,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0013.json
+++ b/schemas/business/en/stocks_0013.json
@@ -1016,7 +1016,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0014.json
+++ b/schemas/business/en/stocks_0014.json
@@ -1017,7 +1017,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0014.json
+++ b/schemas/business/en/stocks_0014.json
@@ -1017,7 +1017,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0033.json
+++ b/schemas/business/en/stocks_0033.json
@@ -1226,7 +1226,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0033.json
+++ b/schemas/business/en/stocks_0033.json
@@ -1226,7 +1226,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0034.json
+++ b/schemas/business/en/stocks_0034.json
@@ -1226,7 +1226,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0034.json
+++ b/schemas/business/en/stocks_0034.json
@@ -1226,7 +1226,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0051.json
+++ b/schemas/business/en/stocks_0051.json
@@ -670,7 +670,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0051.json
+++ b/schemas/business/en/stocks_0051.json
@@ -670,7 +670,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0052.json
+++ b/schemas/business/en/stocks_0052.json
@@ -670,7 +670,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0052.json
+++ b/schemas/business/en/stocks_0052.json
@@ -670,7 +670,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0057.json
+++ b/schemas/business/en/stocks_0057.json
@@ -1020,7 +1020,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0057.json
+++ b/schemas/business/en/stocks_0057.json
@@ -1020,7 +1020,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0058.json
+++ b/schemas/business/en/stocks_0058.json
@@ -1020,7 +1020,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0058.json
+++ b/schemas/business/en/stocks_0058.json
@@ -1020,7 +1020,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0061.json
+++ b/schemas/business/en/stocks_0061.json
@@ -670,7 +670,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0061.json
+++ b/schemas/business/en/stocks_0061.json
@@ -670,7 +670,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0070.json
+++ b/schemas/business/en/stocks_0070.json
@@ -682,7 +682,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/stocks_0070.json
+++ b/schemas/business/en/stocks_0070.json
@@ -682,7 +682,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/ukis_0001.json
+++ b/schemas/business/en/ukis_0001.json
@@ -7379,7 +7379,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/ukis_0001.json
+++ b/schemas/business/en/ukis_0001.json
@@ -7379,7 +7379,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/ukis_0002.json
+++ b/schemas/business/en/ukis_0002.json
@@ -7379,7 +7379,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/ukis_0002.json
+++ b/schemas/business/en/ukis_0002.json
@@ -7379,7 +7379,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies182_0006.json
+++ b/schemas/business/en/vacancies182_0006.json
@@ -322,7 +322,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies182_0006.json
+++ b/schemas/business/en/vacancies182_0006.json
@@ -322,7 +322,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies183_0006.json
+++ b/schemas/business/en/vacancies183_0006.json
@@ -322,7 +322,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies183_0006.json
+++ b/schemas/business/en/vacancies183_0006.json
@@ -322,7 +322,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies184_0006.json
+++ b/schemas/business/en/vacancies184_0006.json
@@ -322,7 +322,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies184_0006.json
+++ b/schemas/business/en/vacancies184_0006.json
@@ -322,7 +322,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies185_0005.json
+++ b/schemas/business/en/vacancies185_0005.json
@@ -322,7 +322,7 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": true,
+    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {

--- a/schemas/business/en/vacancies185_0005.json
+++ b/schemas/business/en/vacancies185_0005.json
@@ -322,7 +322,6 @@
     }
   ],
   "post_submission": {
-    "confirmation_email": false,
     "feedback": true,
     "view_response": true,
     "guidance": {


### PR DESCRIPTION
### What is the context of this PR?
Confirmation email shouldn't be enabled in production, as it is not full supported. They should never be enabled for business surveys, as they have accounts that manage email notification.

Runner latest change allow confirmation email to be used but since they are not fully supported, they shouldn't be enabled as it causes errors given users are able to request email confirmations.

### How to review
Ensure no schemas have confirmation email enabled.