### PR TITLE
Use v2 version of docker compose command

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 tag=`cat .schema-validator-version`
-TAG=${tag} docker-compose -f docker-compose-schema-validator.yml up -d
+TAG=${tag} docker compose -f docker-compose-schema-validator.yml up -d


### PR DESCRIPTION
### What is the context of this PR?
This adds docker compose V2 command syntax (previously hyphenated `docker-compose`) since the old version is no longer supported. More info: https://docs.docker.com/compose/migrate/.

### How to review
Check if validator steps in actions work as expected.
