### PR TITLE
Update schemas release task with appropriate permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Zip artifacts
         run: zip -r schemas.zip schemas
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         with:
           files: schemas.zip
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   add-schemas-to-release:
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### What is the context of this PR?
Updates the release with the appropriate permissions `write`, as the release action was failing to generate the schemas zip file. See failed run: https://github.com/ONSdigital/eq-questionnaire-schemas/actions/runs/13283731695

Also updates the `softprops/action-gh-release` to the latest version.

### How to review
Check the permissions and the updated library.
