### PR TITLE
Fix validate schemas script

### DIFF
--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -84,7 +84,6 @@ def validate_schema(schema_path):
 
 def main():
     # pylint: disable=broad-exception-caught
-    error = False
     passed = 0
     failed = 0
 
@@ -120,13 +119,13 @@ def main():
                         f"\033[31mHTTP Status @ /validate: {result_response}\033[0m"
                     )
                     logging.error(f"\033[31mHTTP Status: {formatted_json}\033[0m")
-                    error = True
                     failed += 1
             except Exception as e:
                 logging.error(f"\033[31mError processing {schema}: {e}\033[0m")
+                failed += 1
 
     logging.info(f"\033[32m{passed} passed\033[0m - \033[31m{failed} failed\033[0m")
-    if error:
+    if passed != len(schemas):
         sys.exit(1)
 
 


### PR DESCRIPTION
### What is the context of this PR?
This introduces improvements to our error handling in `validate_schemas` script. It adds logic to increment the failed counter when an exception occurs during schema processing. We also ensure now that schema processing errors are properly counted towards the total failure count and the whole process of capturing errors was simplified.

### How to review
Verify that the error handling logic correctly increments the failed counter when an exception occurs during schema processing. Test & confirm that the script exits with a non-zero status code if the number of passed schemas does not match the total schemas processed. Nothing changed in logging but you can double check if schema errors are properly logged.