### PR TITLE
EQS 241- Reference docker scripts to point to GAR

### DIFF
--- a/docker-compose-schema-validator.yml
+++ b/docker-compose-schema-validator.yml
@@ -3,7 +3,7 @@ version: '3'
 
 services:
   ajv-validator:
-    image: onsdigital/eq-questionnaire-validator:${TAG}-ajv
+    image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/eq-questionnaire-validator-ajv:${TAG}
     networks:
       - eq-schema
     ports:
@@ -15,7 +15,7 @@ services:
       retries: 20
 
   py-validator:
-    image: onsdigital/eq-questionnaire-validator:${TAG}
+    image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/eq-questionnaire-validator:${TAG}
     networks:
       - eq-schema
     environment:


### PR DESCRIPTION
### What is the context of this PR?
We lost our license to use Dockerhub as an org, we have stopped being able to push app images to anywhere other than Google's artifact registry. 

Docker compose scripts need to remove references to the ONS digital dockerhub org, and point at the artifact registry instead.

This PR is a change to point docker compose scripts in eQ applications to GAR rather than Dockerhub


### How to review
clone ONSdigital/eq-questionnaire-runner and checkout into the branch
From the root of the repo run the below to get eq-questionnaire-runner running:
RUNNER_ENV_FILE=.development.env docker compose up -d

To launch a survey, navigate to http://localhost:8000/

This will:
Pull all the services (launcher, sds, cir) from GAR
Start them in the background

https://github.com/ONSdigital/eq-questionnaire-runner/blob/main/README.md