### PR TITLE
Revert docker script to use release tag version instead of latest 

### DIFF
--- a/docker-compose-schema-validator.yml
+++ b/docker-compose-schema-validator.yml
@@ -1,6 +1,6 @@
 services:
   ajv-validator:
-    image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/eq-questionnaire-validator-ajv:latest
+    image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/eq-questionnaire-validator-ajv:${TAG}
     networks:
       - eq-schema
     ports:
@@ -12,7 +12,7 @@ services:
       retries: 20
 
   py-validator:
-    image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/eq-questionnaire-validator:latest
+    image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/eq-questionnaire-validator:${TAG}
     networks:
       - eq-schema
     environment:


### PR DESCRIPTION
What is the context of this PR?
We have created a Validator on-release pipeline so that we can continue using tagged validator release versions. This was temporarily using the latest image but is now using a release tag version.

How to review
clone ONSdigital/eq-questionnaire-schemas and checkout into the branch

Authenticate to make sure Docker can pull from GAR
gcloud auth login
colima start

From the root of the repo run the below:
Note
This will validate all schemas
make run-validator to run the validator and then run make validate-schemas to validate the schemas
