### PR TITLE
CTE-21: Update repo for census use

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ONSdigital/eq-author @ONSdigital/eq-runner
+* @ONSdigital/eq-census

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# eq-questionnaire-schemas
+# census31-eq-questionnaire-schemas
 
-A registry for questionnaire schemas for eq-questionnaire-runner.
+A registry for census questionnaire schemas for [census31-eq-questionnaire-runner](https://github.com/ONSdigital/census31-eq-questionnaire-runner).
 
 
 ## Setup
@@ -90,13 +90,13 @@ To check that translations are up to date use the following command (This check 
 make test-translation-templates
 ```
 
-## Testing built schemas with eq-questionnaire-runner
+## Testing built schemas with census31-eq-questionnaire-runner
 
 In order to test the schemas in this repo you will need to create symbolic links between the `/schemas` directory in runner and the folders in the schemas directory here. 
 
-For example in your local eq-questionnaire-runner repository, running the following command will create a symbolic link between the business folder here and the schemas directory in runner.
+For example in your local census31-eq-questionnaire-runner repository, running the following command will create a symbolic link between the business folder here and the schemas directory in runner.
 ```bash
-ln -s <PATH_TO_REPO>/eq-questionnaire-schemas/schemas/business <PATH_TO_REPO>/eq-questionnaire-runner/schemas
+ln -s <PATH_TO_REPO>/census31-eq-questionnaire-schemas/schemas/business <PATH_TO_REPO>/census31-eq-questionnaire-runner/schemas
 ```
 You should now be able to launch a questionnaire using one of the schemas.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "census31-eq-questionnaire-schemas"
+name = "eq-questionnaire-schemas"
 version = "0.1.0"
 description = "Census Questionnaire Schemas Repository"
 authors = ["ONSDigital"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = "eq-questionnaire-schemas"
+name = "census31-eq-questionnaire-schemas"
 version = "0.1.0"
-description = "Questionnaire Schemas Repository"
+description = "Census Questionnaire Schemas Repository"
 authors = ["ONSDigital"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
### What is the context of this PR?
Updates the repo replacing references to `eq-questionnaire-*` with `census31-eq-questionnaire-*` and sets the CODEOWNERS to the new team.

https://officefornationalstatistics.atlassian.net/browse/CTE-21

### How to review
- Check the changes are correct
- Check that there are no missed references
